### PR TITLE
feat(transactions): add infinite scroll with layout preference toggle

### DIFF
--- a/prisma/migrations/20260223014527_add_transaction_layout/migration.sql
+++ b/prisma/migrations/20260223014527_add_transaction_layout/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "transaction_layout" TEXT NOT NULL DEFAULT 'infinite';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   quickExpenseCategories  String[]      @default([]) @map("quick_expense_categories")
   quickIncomeCategories   String[]      @default([]) @map("quick_income_categories")
   receiptScanEnabled      Boolean       @default(false) @map("receipt_scan_enabled")
+  transactionLayout       String        @default("infinite") @map("transaction_layout")
   transactions            Transaction[]
   categories              Category[]
   createdAt    DateTime      @default(now()) @map("created_at")

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -21,7 +21,7 @@ export default async function AppLayout({
   // Fetch currency preference from DB so it's available on first render
   const dbUser = await prisma.user.findUnique({
     where: { id: session.user.id },
-    select: { currency: true, receiptScanEnabled: true },
+    select: { currency: true, receiptScanEnabled: true, transactionLayout: true },
   });
 
   return (
@@ -31,6 +31,7 @@ export default async function AppLayout({
           ...session.user,
           currency: dbUser?.currency ?? "PHP",
           receiptScanEnabled: dbUser?.receiptScanEnabled ?? false,
+          transactionLayout: (dbUser?.transactionLayout as "infinite" | "pagination") ?? "infinite",
         }}
       >
         <PrivacyProvider>

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { User, Lock, Check, Loader2, Sparkles, ScanLine } from "lucide-react";
+import { User, Lock, Check, Loader2, Sparkles, ScanLine, Rows3 } from "lucide-react";
 import {
   updateProfileSchema,
   changePasswordSchema,
@@ -429,6 +429,7 @@ function PasswordForm({ form, onSubmit, success, error }: PasswordFormProps) {
 function FeaturesForm() {
   const { user, setUser } = useUser();
   const [saving, setSaving] = useState(false);
+  const [savingLayout, setSavingLayout] = useState(false);
 
   const handleToggle = async () => {
     const newValue = !user.receiptScanEnabled;
@@ -453,6 +454,30 @@ function FeaturesForm() {
       setUser({ receiptScanEnabled: !newValue });
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleLayoutToggle = async () => {
+    const newValue = user.transactionLayout === "infinite" ? "pagination" : "infinite";
+    const oldValue = user.transactionLayout;
+
+    setUser({ transactionLayout: newValue });
+    setSavingLayout(true);
+
+    try {
+      const res = await fetch("/api/preferences", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transactionLayout: newValue }),
+      });
+
+      if (!res.ok) {
+        setUser({ transactionLayout: oldValue });
+      }
+    } catch {
+      setUser({ transactionLayout: oldValue });
+    } finally {
+      setSavingLayout(false);
     }
   };
 
@@ -496,6 +521,41 @@ function FeaturesForm() {
               className={cn(
                 "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200",
                 user.receiptScanEnabled ? "translate-x-5" : "translate-x-0"
+              )}
+            />
+          </button>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 p-4 rounded-xl border border-cream-300 bg-cream-50/50">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-xl bg-amber-light flex items-center justify-center">
+              <Rows3 className="w-5 h-5 text-amber-dark" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-warm-600">
+                Infinite Scroll
+              </p>
+              <p className="text-xs text-warm-400">
+                Load transactions as you scroll instead of using page navigation
+              </p>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            role="switch"
+            aria-checked={user.transactionLayout === "infinite"}
+            disabled={savingLayout}
+            onClick={handleLayoutToggle}
+            className={cn(
+              "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber/30 disabled:opacity-50 disabled:cursor-not-allowed",
+              user.transactionLayout === "infinite" ? "bg-amber" : "bg-cream-300"
+            )}
+          >
+            <span
+              className={cn(
+                "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200",
+                user.transactionLayout === "infinite" ? "translate-x-5" : "translate-x-0"
               )}
             />
           </button>

--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import {
   Plus,
   Search,
@@ -12,6 +12,7 @@ import {
   Download,
   Check,
   X,
+  Loader2,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { formatCurrency, cn } from "@/lib/utils";
@@ -113,6 +114,7 @@ export default function TransactionsPage() {
   const { hideAmounts } = usePrivacy();
   const { user } = useUser();
   const currency = user.currency;
+  const isInfinite = user.transactionLayout === "infinite";
   const [data, setData] = useState<TransactionsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<"ALL" | "INCOME" | "EXPENSE">("ALL");
@@ -122,6 +124,12 @@ export default function TransactionsPage() {
   });
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
+
+  // Infinite scroll state
+  const [allTransactions, setAllTransactions] = useState<TransactionWithCategory[]>([]);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const sentinelRef = useRef<HTMLDivElement>(null);
 
   // Selection
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -137,36 +145,89 @@ export default function TransactionsPage() {
 
   /* ---- Data fetching ---- */
 
-  const fetchTransactions = useCallback(async () => {
-    setLoading(true);
-    const params = new URLSearchParams({ page: String(page), limit: "15", month });
+  const fetchTransactions = useCallback(async (pageToFetch: number, append: boolean) => {
+    if (append) {
+      setLoadingMore(true);
+    } else {
+      setLoading(true);
+    }
+
+    const params = new URLSearchParams({ page: String(pageToFetch), limit: "15", month });
     if (filter !== "ALL") params.set("type", filter);
     const res = await fetch(`/api/transactions?${params}`);
-    const json = await res.json();
-    setData(json);
-    setLoading(false);
-  }, [page, month, filter]);
+    const json: TransactionsResponse = await res.json();
 
-  useEffect(() => {
-    fetchTransactions();
-  }, [fetchTransactions]);
+    if (append) {
+      setAllTransactions((prev) => [...prev, ...json.transactions]);
+      setHasMore(pageToFetch < json.pagination.totalPages);
+      setLoadingMore(false);
+      setData(json);
+    } else {
+      setData(json);
+      if (isInfinite) {
+        setAllTransactions(json.transactions);
+        setHasMore(1 < json.pagination.totalPages);
+      }
+      setLoading(false);
+    }
+  }, [month, filter, isInfinite]);
 
-  // Reset page & selection when filters change
+  // Initial fetch + reset on filter/month change
   useEffect(() => {
     setPage(1);
     setSelectedIds(new Set());
-  }, [filter, month]);
+    fetchTransactions(1, false);
+  }, [filter, month, fetchTransactions]);
+
+  // Pagination mode: fetch when page changes (page > 1)
+  useEffect(() => {
+    if (isInfinite || page === 1) return;
+    fetchTransactions(page, false);
+  }, [page, isInfinite, fetchTransactions]);
+
+  // Infinite scroll: IntersectionObserver on sentinel
+  useEffect(() => {
+    if (!isInfinite) return;
+
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry.isIntersecting && hasMore && !loadingMore && !loading) {
+          setPage((prev) => {
+            const nextPage = prev + 1;
+            fetchTransactions(nextPage, true);
+            return nextPage;
+          });
+        }
+      },
+      { rootMargin: "200px" }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [isInfinite, hasMore, loadingMore, loading, fetchTransactions]);
+
+  const refreshAfterMutation = useCallback(() => {
+    setPage(1);
+    setAllTransactions([]);
+    fetchTransactions(1, false);
+  }, [fetchTransactions]);
 
   /* ---- Filtered & grouped data ---- */
 
-  const filteredTransactions = data?.transactions.filter((tx) =>
+  const sourceTransactions = isInfinite ? allTransactions : (data?.transactions ?? []);
+
+  const filteredTransactions = sourceTransactions.filter((tx) =>
     search
       ? tx.description.toLowerCase().includes(search.toLowerCase()) ||
         tx.category.name.toLowerCase().includes(search.toLowerCase())
       : true
   );
 
-  const dateGroups = filteredTransactions ? groupByDate(filteredTransactions) : [];
+  const dateGroups = groupByDate(filteredTransactions);
 
   /* ---- Selection handlers ---- */
 
@@ -180,7 +241,7 @@ export default function TransactionsPage() {
   };
 
   const toggleSelectAll = () => {
-    if (!filteredTransactions) return;
+    if (filteredTransactions.length === 0) return;
     const allIds = filteredTransactions.map((tx) => tx.id);
     const allSelected = allIds.every((id) => selectedIds.has(id));
     setSelectedIds(allSelected ? new Set() : new Set(allIds));
@@ -189,7 +250,6 @@ export default function TransactionsPage() {
   const clearSelection = () => setSelectedIds(new Set());
 
   const allSelected =
-    filteredTransactions &&
     filteredTransactions.length > 0 &&
     filteredTransactions.every((tx) => selectedIds.has(tx.id));
 
@@ -202,7 +262,7 @@ export default function TransactionsPage() {
       body: JSON.stringify(input),
     });
     setShowForm(false);
-    fetchTransactions();
+    refreshAfterMutation();
   };
 
   const handleUpdate = async (input: TransactionInput) => {
@@ -213,7 +273,7 @@ export default function TransactionsPage() {
       body: JSON.stringify(input),
     });
     setEditingTransaction(null);
-    fetchTransactions();
+    refreshAfterMutation();
   };
 
   const handleDelete = async () => {
@@ -222,7 +282,7 @@ export default function TransactionsPage() {
     await fetch(`/api/transactions/${deletingTransaction.id}`, { method: "DELETE" });
     setDeleteLoading(false);
     setDeletingTransaction(null);
-    fetchTransactions();
+    refreshAfterMutation();
   };
 
   const handleBulkDelete = async () => {
@@ -235,11 +295,11 @@ export default function TransactionsPage() {
     setDeleteLoading(false);
     setShowBulkDelete(false);
     setSelectedIds(new Set());
-    fetchTransactions();
+    refreshAfterMutation();
   };
 
   const handleExport = () => {
-    if (!filteredTransactions || selectedIds.size === 0) return;
+    if (filteredTransactions.length === 0 || selectedIds.size === 0) return;
     const selected = filteredTransactions.filter((tx) => selectedIds.has(tx.id));
     const csv = generateCsv(selected);
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
@@ -252,7 +312,7 @@ export default function TransactionsPage() {
   };
 
   const handleBulkEdit = () => {
-    if (selectedIds.size !== 1 || !filteredTransactions) return;
+    if (selectedIds.size !== 1 || filteredTransactions.length === 0) return;
     const tx = filteredTransactions.find((t) => selectedIds.has(t.id));
     if (tx) {
       setEditingTransaction(tx);
@@ -284,7 +344,11 @@ export default function TransactionsPage() {
         <div>
           <h1 className="font-serif text-2xl lg:text-3xl text-warm-700">Transactions</h1>
           <p className="text-warm-400 text-sm mt-1">
-            {data ? `${data.pagination.total} total` : "Loading..."}
+            {data
+              ? isInfinite
+                ? `${allTransactions.length} of ${data.pagination.total} loaded`
+                : `${data.pagination.total} total`
+              : "Loading..."}
           </p>
         </div>
         <button
@@ -532,8 +596,26 @@ export default function TransactionsPage() {
               </div>
             ))}
 
-            {/* Pagination */}
-            {data && data.pagination.totalPages > 1 && (
+            {/* Infinite scroll: loading + sentinel */}
+            {isInfinite && (
+              <>
+                {loadingMore && (
+                  <div className="flex items-center justify-center py-6 border-t border-cream-200">
+                    <Loader2 className="w-5 h-5 text-warm-300 animate-spin" />
+                    <span className="ml-2 text-sm text-warm-400">Loading more...</span>
+                  </div>
+                )}
+                {!hasMore && allTransactions.length > 0 && (
+                  <div className="text-center py-4 border-t border-cream-200">
+                    <p className="text-xs text-warm-300">All transactions loaded</p>
+                  </div>
+                )}
+                <div ref={sentinelRef} className="h-1" />
+              </>
+            )}
+
+            {/* Pagination (non-infinite mode) */}
+            {!isInfinite && data && data.pagination.totalPages > 1 && (
               <div className="flex items-center justify-between px-5 py-3 border-t border-cream-200">
                 <p className="text-xs text-warm-400">
                   Page {data.pagination.page} of {data.pagination.totalPages}

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -13,6 +13,7 @@ export async function GET() {
       quickExpenseCategories: true,
       quickIncomeCategories: true,
       receiptScanEnabled: true,
+      transactionLayout: true,
     },
   });
 
@@ -21,6 +22,7 @@ export async function GET() {
     quickExpenseCategories: user?.quickExpenseCategories ?? [],
     quickIncomeCategories: user?.quickIncomeCategories ?? [],
     receiptScanEnabled: user?.receiptScanEnabled ?? false,
+    transactionLayout: user?.transactionLayout ?? "infinite",
   });
 }
 
@@ -64,6 +66,17 @@ export async function PATCH(request: Request) {
     data.quickIncomeCategories = ids;
   }
 
+  if ("transactionLayout" in body) {
+    const layout = body.transactionLayout;
+    if (layout !== "infinite" && layout !== "pagination") {
+      return NextResponse.json(
+        { error: "transactionLayout must be 'infinite' or 'pagination'" },
+        { status: 400 }
+      );
+    }
+    data.transactionLayout = layout;
+  }
+
   const user = await prisma.user.update({
     where: { id: userId },
     data,
@@ -72,6 +85,7 @@ export async function PATCH(request: Request) {
       quickExpenseCategories: true,
       quickIncomeCategories: true,
       receiptScanEnabled: true,
+      transactionLayout: true,
     },
   });
 
@@ -80,5 +94,6 @@ export async function PATCH(request: Request) {
     quickExpenseCategories: user.quickExpenseCategories,
     quickIncomeCategories: user.quickIncomeCategories,
     receiptScanEnabled: user.receiptScanEnabled,
+    transactionLayout: user.transactionLayout,
   });
 }

--- a/src/components/user-provider.tsx
+++ b/src/components/user-provider.tsx
@@ -7,6 +7,7 @@ interface UserInfo {
   email: string;
   currency: string;
   receiptScanEnabled: boolean;
+  transactionLayout: "infinite" | "pagination";
 }
 
 interface UserContextValue {
@@ -15,7 +16,7 @@ interface UserContextValue {
 }
 
 const UserContext = createContext<UserContextValue>({
-  user: { name: "", email: "", currency: "PHP", receiptScanEnabled: false },
+  user: { name: "", email: "", currency: "PHP", receiptScanEnabled: false, transactionLayout: "infinite" },
   setUser: () => {},
 });
 


### PR DESCRIPTION
- Add transactionLayout preference to User model (default: infinite)
- Implement IntersectionObserver-based infinite scroll on transactions page
- Support dual-mode: infinite scroll or pagination, switchable per user
- Add Infinite Scroll toggle in Profile > Features tab
- Wire preference through API, UserProvider, and app layout