### PR TITLE
feat(auth): add user roles (ADMIN, FREE, PAID) with admin panel

### DIFF
--- a/prisma/migrations/20260223115852_add_user_role/migration.sql
+++ b/prisma/migrations/20260223115852_add_user_role/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "UserRole" AS ENUM ('ADMIN', 'FREE', 'PAID');
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "role" "UserRole" NOT NULL DEFAULT 'FREE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,11 +12,18 @@ enum TransactionType {
   EXPENSE
 }
 
+enum UserRole {
+  ADMIN
+  FREE
+  PAID
+}
+
 model User {
   id           String        @id @default(cuid())
   name         String
   email        String        @unique
   password     String
+  role         UserRole      @default(FREE)
   hideAmounts             Boolean       @default(false) @map("hide_amounts")
   currency                String        @default("PHP")
   quickExpenseCategories  String[]      @default([]) @map("quick_expense_categories")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -30,24 +30,31 @@ const main = async () => {
   });
 
   if (existingCount > 0) {
-    // eslint-disable-next-line no-console
     console.log(`Default categories already seeded (${existingCount} found). Skipping.`);
-    return;
+  } else {
+    await prisma.category.createMany({
+      data: DEFAULT_CATEGORIES.map((cat) => ({
+        name: cat.name,
+        type: cat.type,
+        icon: cat.icon,
+        color: cat.color,
+        isDefault: true,
+        userId: null,
+      })),
+    });
+
+    console.log(`Seeded ${DEFAULT_CATEGORIES.length} default categories`);
   }
 
-  await prisma.category.createMany({
-    data: DEFAULT_CATEGORIES.map((cat) => ({
-      name: cat.name,
-      type: cat.type,
-      icon: cat.icon,
-      color: cat.color,
-      isDefault: true,
-      userId: null,
-    })),
+  // Set admin role for the primary admin account (always runs)
+  const adminResult = await prisma.user.updateMany({
+    where: { email: "chrisgen19@gmail.com" },
+    data: { role: "ADMIN" },
   });
 
-  // eslint-disable-next-line no-console
-  console.log(`Seeded ${DEFAULT_CATEGORIES.length} default categories`);
+  if (adminResult.count > 0) {
+    console.log("Set admin role for chrisgen19@gmail.com");
+  }
 };
 
 main()

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Shield, Users, ArrowLeftRight } from "lucide-react";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+import type { UserRole } from "@prisma/client";
+
+interface AdminUser {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+  createdAt: string;
+  _count: { transactions: number };
+}
+
+const ROLE_STYLES: Record<UserRole, { bg: string; text: string }> = {
+  ADMIN: { bg: "bg-purple-100", text: "text-purple-700" },
+  PAID: { bg: "bg-amber-light", text: "text-amber-dark" },
+  FREE: { bg: "bg-cream-200", text: "text-warm-500" },
+};
+
+export default function AdminPage() {
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [updatingId, setUpdatingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      try {
+        const res = await fetch("/api/admin/users");
+        if (!res.ok) throw new Error("Failed to fetch users");
+        const data = await res.json();
+        setUsers(data);
+      } catch {
+        setError("Failed to load users. Please try again.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUsers();
+  }, []);
+
+  const handleRoleChange = async (userId: string, newRole: "FREE" | "PAID") => {
+    setUpdatingId(userId);
+    try {
+      const res = await fetch(`/api/admin/users/${userId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: newRole }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? "Failed to update role");
+      }
+
+      const updated = await res.json();
+      setUsers((prev) =>
+        prev.map((u) => (u.id === userId ? { ...u, role: updated.role } : u))
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update role");
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  };
+
+  const totalUsers = users.length;
+  const paidUsers = users.filter((u) => u.role === "PAID").length;
+  const freeUsers = users.filter((u) => u.role === "FREE").length;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="font-serif text-2xl text-warm-700">Admin</h1>
+        <p className="text-warm-400 text-sm mt-1">Manage users and roles</p>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-3">
+        <div className="bg-white rounded-2xl border border-cream-300/60 p-4 shadow-soft">
+          <div className="flex items-center gap-2 text-warm-400 mb-1">
+            <Users className="w-4 h-4" />
+            <span className="text-xs font-medium">Total</span>
+          </div>
+          <p className="text-xl font-serif text-warm-700">
+            {loading ? "—" : totalUsers}
+          </p>
+        </div>
+        <div className="bg-white rounded-2xl border border-cream-300/60 p-4 shadow-soft">
+          <div className="flex items-center gap-2 text-amber mb-1">
+            <Shield className="w-4 h-4" />
+            <span className="text-xs font-medium">Paid</span>
+          </div>
+          <p className="text-xl font-serif text-warm-700">
+            {loading ? "—" : paidUsers}
+          </p>
+        </div>
+        <div className="bg-white rounded-2xl border border-cream-300/60 p-4 shadow-soft">
+          <div className="flex items-center gap-2 text-warm-400 mb-1">
+            <Users className="w-4 h-4" />
+            <span className="text-xs font-medium">Free</span>
+          </div>
+          <p className="text-xl font-serif text-warm-700">
+            {loading ? "—" : freeUsers}
+          </p>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="bg-expense-light border border-expense/20 text-expense rounded-xl px-4 py-3 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* User List */}
+      <div className="bg-white rounded-2xl border border-cream-300/60 shadow-soft overflow-hidden">
+        <div className="px-5 py-4 border-b border-cream-200">
+          <h2 className="font-serif text-lg text-warm-700">Users</h2>
+          <p className="text-xs text-warm-400 mt-0.5">
+            Role changes take effect on the user&apos;s next login
+          </p>
+        </div>
+
+        {loading ? (
+          <div className="divide-y divide-cream-200">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="px-5 py-4 flex items-center gap-4">
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-32 bg-cream-200 rounded animate-pulse" />
+                  <div className="h-3 w-48 bg-cream-100 rounded animate-pulse" />
+                </div>
+                <div className="h-8 w-20 bg-cream-200 rounded-lg animate-pulse" />
+              </div>
+            ))}
+          </div>
+        ) : users.length === 0 ? (
+          <div className="px-5 py-12 text-center text-warm-400 text-sm">
+            No users found
+          </div>
+        ) : (
+          <div className="divide-y divide-cream-200">
+            {users.map((user) => (
+              <motion.div
+                key={user.id}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                className="px-5 py-4 flex items-center gap-4"
+              >
+                {/* User info */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium text-warm-600 truncate">
+                      {user.name}
+                    </p>
+                    <span
+                      className={cn(
+                        "text-[10px] font-semibold px-2 py-0.5 rounded-full uppercase tracking-wide shrink-0",
+                        ROLE_STYLES[user.role].bg,
+                        ROLE_STYLES[user.role].text
+                      )}
+                    >
+                      {user.role}
+                    </span>
+                  </div>
+                  <p className="text-xs text-warm-400 truncate">{user.email}</p>
+                  <div className="flex items-center gap-3 mt-1 text-[11px] text-warm-300">
+                    <span className="flex items-center gap-1">
+                      <ArrowLeftRight className="w-3 h-3" />
+                      {user._count.transactions} transactions
+                    </span>
+                    <span>Joined {formatDate(user.createdAt)}</span>
+                  </div>
+                </div>
+
+                {/* Role toggle (non-admin users only) */}
+                {user.role !== "ADMIN" && (
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <button
+                      onClick={() => handleRoleChange(user.id, "FREE")}
+                      disabled={updatingId === user.id || user.role === "FREE"}
+                      className={cn(
+                        "px-3 py-1.5 rounded-lg text-xs font-medium transition-all",
+                        user.role === "FREE"
+                          ? "bg-warm-600 text-white"
+                          : "bg-cream-100 text-warm-400 hover:bg-cream-200"
+                      )}
+                    >
+                      Free
+                    </button>
+                    <button
+                      onClick={() => handleRoleChange(user.id, "PAID")}
+                      disabled={updatingId === user.id || user.role === "PAID"}
+                      className={cn(
+                        "px-3 py-1.5 rounded-lg text-xs font-medium transition-all",
+                        user.role === "PAID"
+                          ? "bg-amber text-white"
+                          : "bg-cream-100 text-warm-400 hover:bg-cream-200"
+                      )}
+                    >
+                      Paid
+                    </button>
+                    {updatingId === user.id && (
+                      <div className="w-4 h-4 border-2 border-amber border-t-transparent rounded-full animate-spin" />
+                    )}
+                  </div>
+                )}
+              </motion.div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -21,7 +21,7 @@ export default async function AppLayout({
   // Fetch currency preference from DB so it's available on first render
   const dbUser = await prisma.user.findUnique({
     where: { id: session.user.id },
-    select: { currency: true, receiptScanEnabled: true, transactionLayout: true },
+    select: { currency: true, receiptScanEnabled: true, transactionLayout: true, role: true },
   });
 
   return (
@@ -32,6 +32,7 @@ export default async function AppLayout({
           currency: dbUser?.currency ?? "PHP",
           receiptScanEnabled: dbUser?.receiptScanEnabled ?? false,
           transactionLayout: (dbUser?.transactionLayout as "infinite" | "pagination") ?? "infinite",
+          role: dbUser?.role ?? "FREE",
         }}
       >
         <PrivacyProvider>

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -28,8 +28,14 @@ const CURRENCIES = [
 
 type Tab = "personal" | "password" | "features";
 
+const ROLE_BADGE_STYLES: Record<string, string> = {
+  ADMIN: "bg-purple-100 text-purple-700",
+  PAID: "bg-amber-light text-amber-dark",
+  FREE: "bg-cream-200 text-warm-500",
+};
+
 export default function ProfilePage() {
-  const { setUser } = useUser();
+  const { user, setUser } = useUser();
   const [activeTab, setActiveTab] = useState<Tab>("personal");
   const [loading, setLoading] = useState(true);
   const [profileSuccess, setProfileSuccess] = useState("");
@@ -150,9 +156,19 @@ export default function ProfilePage() {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="font-serif text-2xl lg:text-3xl text-warm-700">
-          Profile Settings
-        </h1>
+        <div className="flex items-center gap-3">
+          <h1 className="font-serif text-2xl lg:text-3xl text-warm-700">
+            Profile Settings
+          </h1>
+          <span
+            className={cn(
+              "text-[10px] font-semibold px-2.5 py-0.5 rounded-full uppercase tracking-wide",
+              ROLE_BADGE_STYLES[user.role]
+            )}
+          >
+            {user.role}
+          </span>
+        </div>
         <p className="text-warm-400 mt-1">Manage your account settings</p>
       </div>
 
@@ -428,6 +444,7 @@ function PasswordForm({ form, onSubmit, success, error }: PasswordFormProps) {
 
 function FeaturesForm() {
   const { user, setUser } = useUser();
+  const canUsePaidFeatures = user.role === "PAID" || user.role === "ADMIN";
   const [saving, setSaving] = useState(false);
   const [savingLayout, setSavingLayout] = useState(false);
 
@@ -506,24 +523,30 @@ function FeaturesForm() {
             </div>
           </div>
 
-          <button
-            type="button"
-            role="switch"
-            aria-checked={user.receiptScanEnabled}
-            disabled={saving}
-            onClick={handleToggle}
-            className={cn(
-              "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber/30 disabled:opacity-50 disabled:cursor-not-allowed",
-              user.receiptScanEnabled ? "bg-amber" : "bg-cream-300"
-            )}
-          >
-            <span
+          {canUsePaidFeatures ? (
+            <button
+              type="button"
+              role="switch"
+              aria-checked={user.receiptScanEnabled}
+              disabled={saving}
+              onClick={handleToggle}
               className={cn(
-                "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200",
-                user.receiptScanEnabled ? "translate-x-5" : "translate-x-0"
+                "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber/30 disabled:opacity-50 disabled:cursor-not-allowed",
+                user.receiptScanEnabled ? "bg-amber" : "bg-cream-300"
               )}
-            />
-          </button>
+            >
+              <span
+                className={cn(
+                  "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200",
+                  user.receiptScanEnabled ? "translate-x-5" : "translate-x-0"
+                )}
+              />
+            </button>
+          ) : (
+            <span className="text-xs text-warm-400 bg-cream-200 px-3 py-1 rounded-full">
+              Paid only
+            </span>
+          )}
         </div>
 
         <div className="flex items-center justify-between gap-4 p-4 rounded-xl border border-cream-300 bg-cream-50/50">

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/session";
+import { z } from "zod";
+
+const updateRoleSchema = z.object({
+  role: z.enum(["FREE", "PAID"]),
+});
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const admin = await requireAdmin();
+  if (admin instanceof NextResponse) return admin;
+
+  const { id } = await params;
+
+  try {
+    const body = await request.json();
+    const { role } = updateRoleSchema.parse(body);
+
+    // Prevent changing own role
+    if (id === admin.id) {
+      return NextResponse.json(
+        { error: "Cannot change your own role" },
+        { status: 400 }
+      );
+    }
+
+    const user = await prisma.user.findUnique({ where: { id } });
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Prevent changing another admin's role
+    if (user.role === "ADMIN") {
+      return NextResponse.json(
+        { error: "Cannot change another admin's role" },
+        { status: 400 }
+      );
+    }
+
+    const updated = await prisma.user.update({
+      where: { id },
+      data: { role },
+      select: { id: true, name: true, email: true, role: true },
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+    }
+    return NextResponse.json(
+      { error: "Failed to update user role" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/session";
+
+export async function GET() {
+  const admin = await requireAdmin();
+  if (admin instanceof NextResponse) return admin;
+
+  const users = await prisma.user.findMany({
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      createdAt: true,
+      _count: { select: { transactions: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json(users);
+}

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -12,6 +12,7 @@ import {
   Wallet,
   User,
   ScanLine,
+  Shield,
 } from "lucide-react";
 import { cn, compressImage } from "@/lib/utils";
 import { motion } from "framer-motion";
@@ -38,6 +39,7 @@ export function AppShell({ children }: AppShellProps) {
   const pathname = usePathname();
   const router = useRouter();
   const { user } = useUser();
+  const canUsePaidFeatures = user.role === "PAID" || user.role === "ADMIN";
   const [scanOpen, setScanOpen] = useState(false);
 
   // OCR scanning state
@@ -159,6 +161,27 @@ export function AppShell({ children }: AppShellProps) {
               </Link>
             );
           })}
+          {user.role === "ADMIN" && (
+            <Link
+              href="/admin"
+              className={cn(
+                "flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all duration-200 relative",
+                pathname === "/admin"
+                  ? "bg-amber-light text-amber-dark"
+                  : "text-warm-400 hover:text-warm-600 hover:bg-cream-100"
+              )}
+            >
+              {pathname === "/admin" && (
+                <motion.div
+                  layoutId="sidebar-active"
+                  className="absolute inset-0 bg-amber-light rounded-xl"
+                  transition={{ type: "spring", duration: 0.4, bounce: 0.15 }}
+                />
+              )}
+              <Shield className="w-5 h-5 relative z-10" />
+              <span className="relative z-10">Admin</span>
+            </Link>
+          )}
         </nav>
 
         {/* User section */}
@@ -233,7 +256,7 @@ export function AppShell({ children }: AppShellProps) {
               </Link>
             );
           })}
-          {user.receiptScanEnabled && (
+          {user.receiptScanEnabled && canUsePaidFeatures && (
             <button
               type="button"
               onClick={() => setScanOpen(true)}

--- a/src/components/user-provider.tsx
+++ b/src/components/user-provider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, useCallback } from "react";
+import type { UserRole } from "@prisma/client";
 
 interface UserInfo {
   name: string;
@@ -8,6 +9,7 @@ interface UserInfo {
   currency: string;
   receiptScanEnabled: boolean;
   transactionLayout: "infinite" | "pagination";
+  role: UserRole;
 }
 
 interface UserContextValue {
@@ -16,7 +18,7 @@ interface UserContextValue {
 }
 
 const UserContext = createContext<UserContextValue>({
-  user: { name: "", email: "", currency: "PHP", receiptScanEnabled: false, transactionLayout: "infinite" },
+  user: { name: "", email: "", currency: "PHP", receiptScanEnabled: false, transactionLayout: "infinite", role: "FREE" },
   setUser: () => {},
 });
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,5 @@
 import type { NextAuthOptions } from "next-auth";
+import type { UserRole } from "@prisma/client";
 import CredentialsProvider from "next-auth/providers/credentials";
 import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
@@ -34,6 +35,7 @@ export const authOptions: NextAuthOptions = {
           id: user.id,
           name: user.name,
           email: user.email,
+          role: user.role,
         };
       },
     }),
@@ -45,12 +47,14 @@ export const authOptions: NextAuthOptions = {
     async jwt({ token, user }) {
       if (user) {
         token.id = user.id;
+        token.role = (user as unknown as { role: UserRole }).role;
       }
       return token;
     },
     async session({ session, token }) {
       if (session.user) {
         session.user.id = token.id as string;
+        session.user.role = token.role;
       }
       return session;
     },

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,6 +1,12 @@
 import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";
 import { authOptions } from "@/lib/auth";
+import type { UserRole } from "@prisma/client";
+
+interface AuthUser {
+  id: string;
+  role: UserRole;
+}
 
 /** Get the authenticated user's ID or return a 401 response */
 export const getAuthUserId = async (): Promise<string | NextResponse> => {
@@ -11,4 +17,27 @@ export const getAuthUserId = async (): Promise<string | NextResponse> => {
   }
 
   return session.user.id;
+};
+
+/** Get the authenticated user's ID and role, or return a 401 response */
+export const getAuthUser = async (): Promise<AuthUser | NextResponse> => {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return { id: session.user.id, role: session.user.role };
+};
+
+/** Require ADMIN role, or return 403 */
+export const requireAdmin = async (): Promise<AuthUser | NextResponse> => {
+  const result = await getAuthUser();
+  if (result instanceof NextResponse) return result;
+
+  if (result.role !== "ADMIN") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  return result;
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,32 @@
-export { default } from "next-auth/middleware";
+import { getToken } from "next-auth/jwt";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export async function middleware(request: NextRequest) {
+  const token = await getToken({ req: request });
+  const { pathname } = request.nextUrl;
+
+  // Not authenticated — redirect to login
+  if (!token) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("callbackUrl", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // Admin routes — require ADMIN role
+  if (pathname.startsWith("/admin") && token.role !== "ADMIN") {
+    return NextResponse.redirect(new URL("/dashboard", request.url));
+  }
+
+  return NextResponse.next();
+}
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/transactions/:path*", "/categories/:path*"],
+  matcher: [
+    "/dashboard/:path*",
+    "/transactions/:path*",
+    "/categories/:path*",
+    "/profile/:path*",
+    "/admin/:path*",
+  ],
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
-import type { Category, Transaction, TransactionType } from "@prisma/client";
+import type { Category, Transaction, TransactionType, UserRole } from "@prisma/client";
 
-export type { Category, Transaction, TransactionType };
+export type { Category, Transaction, TransactionType, UserRole };
 
 /** Transaction with its category relation */
 export type TransactionWithCategory = Transaction & {
@@ -46,6 +46,7 @@ declare module "next-auth" {
       id: string;
       name: string;
       email: string;
+      role: UserRole;
     };
   }
 }
@@ -53,5 +54,6 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   interface JWT {
     id: string;
+    role: UserRole;
   }
 }


### PR DESCRIPTION
- Add UserRole enum to Prisma schema with FREE as default
- Flow role through JWT/session callbacks
- Add requireAdmin() helper for admin API protection
- Custom middleware with admin route gating
- Admin page with user list and role toggle (FREE/PAID)
- Gate receipt scanning to PAID/ADMIN users
- Role badge on profile page
- Set chrisgen19@gmail.com as ADMIN via seed