### PR TITLE
perf(scan): optimize receipt scanning speed with parallel processing …

### DIFF
--- a/src/app/api/receipts/scan/route.ts
+++ b/src/app/api/receipts/scan/route.ts
@@ -47,38 +47,7 @@ export async function POST(request: Request) {
       select: { role: true },
     });
 
-    if (user && user.role !== "ADMIN") {
-      const roleSettings = await prisma.appSettings.findUnique({
-        where: { role: user.role },
-      });
-      if (!roleSettings?.receiptScanEnabled) {
-        return NextResponse.json(
-          { error: "Receipt scanning is not available for your account." },
-          { status: 403 }
-        );
-      }
-
-      // Enforce monthly scan limit (0 = unlimited)
-      if (roleSettings.monthlyScanLimit > 0) {
-        const now = new Date();
-        const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
-        const scansThisMonth = await prisma.scanLog.count({
-          where: {
-            userId,
-            createdAt: { gte: monthStart },
-          },
-        });
-
-        if (scansThisMonth >= roleSettings.monthlyScanLimit) {
-          return NextResponse.json(
-            {
-              error: `Monthly scan limit reached (${scansThisMonth}/${roleSettings.monthlyScanLimit}). Limit resets next month.`,
-            },
-            { status: 403 }
-          );
-        }
-      }
-    }
+    // Parse form data while role check runs its course
     const formData = await request.formData();
     const file = formData.get("receipt");
 
@@ -104,15 +73,55 @@ export async function POST(request: Request) {
       );
     }
 
-    // Fetch user's expense categories (default + custom)
-    const categories = await prisma.category.findMany({
-      where: {
-        type: "EXPENSE",
-        OR: [{ isDefault: true }, { userId }],
-      },
-      orderBy: [{ isDefault: "desc" }, { name: "asc" }],
-      select: { id: true, name: true },
-    });
+    // Run permission checks + category fetch in parallel
+    const isAdmin = user?.role === "ADMIN";
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+
+    const [roleSettings, scansThisMonth, categories] = await Promise.all([
+      // Only fetch settings for non-admins
+      !isAdmin && user
+        ? prisma.appSettings.findUnique({ where: { role: user.role } })
+        : null,
+      // Only count scans for non-admins
+      !isAdmin
+        ? prisma.scanLog.count({
+            where: { userId, createdAt: { gte: monthStart } },
+          })
+        : 0,
+      // Always fetch categories (needed for Gemini prompt)
+      prisma.category.findMany({
+        where: {
+          type: "EXPENSE",
+          OR: [{ isDefault: true }, { userId }],
+        },
+        orderBy: [{ isDefault: "desc" }, { name: "asc" }],
+        select: { id: true, name: true },
+      }),
+    ]);
+
+    // Enforce role-based scan permissions for non-admins
+    if (!isAdmin && user) {
+      if (!roleSettings?.receiptScanEnabled) {
+        return NextResponse.json(
+          { error: "Receipt scanning is not available for your account." },
+          { status: 403 }
+        );
+      }
+
+      // Enforce monthly scan limit (0 = unlimited)
+      if (
+        roleSettings.monthlyScanLimit > 0 &&
+        scansThisMonth >= roleSettings.monthlyScanLimit
+      ) {
+        return NextResponse.json(
+          {
+            error: `Monthly scan limit reached (${scansThisMonth}/${roleSettings.monthlyScanLimit}). Limit resets next month.`,
+          },
+          { status: 403 }
+        );
+      }
+    }
 
     const categoryList = categories
       .map((c) => `- "${c.name}" (id: "${c.id}")`)

--- a/src/app/api/transactions/batch/route.ts
+++ b/src/app/api/transactions/batch/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { getAuthUserId } from "@/lib/session";
+import { transactionSchema } from "@/lib/validations";
+
+const batchSchema = z.object({
+  transactions: z.array(transactionSchema).min(1).max(50),
+});
+
+export async function POST(request: Request) {
+  const userId = await getAuthUserId();
+  if (userId instanceof NextResponse) return userId;
+
+  try {
+    const body = await request.json();
+    const { transactions } = batchSchema.parse(body);
+
+    // Use prisma.$transaction with individual creates so we get `include: { category: true }`
+    const created = await prisma.$transaction(
+      transactions.map((t) =>
+        prisma.transaction.create({
+          data: {
+            amount: t.amount,
+            description: t.description,
+            type: t.type,
+            date: new Date(t.date),
+            categoryId: t.categoryId,
+            userId,
+          },
+          include: { category: true },
+        })
+      )
+    );
+
+    return NextResponse.json({ transactions: created }, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+    }
+    return NextResponse.json(
+      { error: "Failed to create transactions" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -153,64 +153,81 @@ export function AppShell({ children }: AppShellProps) {
       setMultiScanItems(initialItems);
       setShowMultiScanReview(true);
 
-      // Scan sequentially so we don't overwhelm the API
-      for (let i = 0; i < files.length; i++) {
-        const file = files[i];
-        const itemId = initialItems[i].id;
+      // Compress all files in parallel (client-side only, no API cost)
+      const compressed = await Promise.all(
+        files.map((f) => compressImage(f).catch(() => f))
+      );
 
-        try {
-          const compressed = await compressImage(file);
-          const formData = new FormData();
-          formData.append("receipt", compressed);
+      // Process API calls with max 2 concurrent requests
+      const CONCURRENCY = 2;
+      let nextIndex = 0;
 
-          const res = await fetch("/api/receipts/scan", {
-            method: "POST",
-            body: formData,
-          });
+      const processNext = async (): Promise<void> => {
+        while (nextIndex < compressed.length) {
+          const i = nextIndex++;
+          const file = compressed[i];
+          const itemId = initialItems[i].id;
 
-          const data = await res.json();
+          try {
+            const formData = new FormData();
+            formData.append("receipt", file);
 
-          if (!res.ok) {
+            const res = await fetch("/api/receipts/scan", {
+              method: "POST",
+              body: formData,
+            });
+
+            const data = await res.json();
+
+            if (!res.ok) {
+              setMultiScanItems((prev) =>
+                prev.map((item) =>
+                  item.id === itemId
+                    ? { ...item, status: "error" as const, error: data.error ?? "Failed to scan receipt." }
+                    : item
+                )
+              );
+              continue;
+            }
+
             setMultiScanItems((prev) =>
               prev.map((item) =>
                 item.id === itemId
-                  ? { ...item, status: "error" as const, error: data.error ?? "Failed to scan receipt." }
+                  ? {
+                      ...item,
+                      status: "success" as const,
+                      data: {
+                        amount: data.amount,
+                        description: data.description,
+                        type: data.type,
+                        date: data.date,
+                        categoryId: data.categoryId,
+                      },
+                    }
                   : item
               )
             );
-            continue;
+
+            // Increment local scan count
+            setUser((prev) => ({ scansUsedThisMonth: prev.scansUsedThisMonth + 1 }));
+          } catch {
+            setMultiScanItems((prev) =>
+              prev.map((item) =>
+                item.id === itemId
+                  ? { ...item, status: "error" as const, error: "Network error. Please try again." }
+                  : item
+              )
+            );
           }
-
-          setMultiScanItems((prev) =>
-            prev.map((item) =>
-              item.id === itemId
-                ? {
-                    ...item,
-                    status: "success" as const,
-                    data: {
-                      amount: data.amount,
-                      description: data.description,
-                      type: data.type,
-                      date: data.date,
-                      categoryId: data.categoryId,
-                    },
-                  }
-                : item
-            )
-          );
-
-          // Increment local scan count
-          setUser((prev) => ({ scansUsedThisMonth: prev.scansUsedThisMonth + 1 }));
-        } catch {
-          setMultiScanItems((prev) =>
-            prev.map((item) =>
-              item.id === itemId
-                ? { ...item, status: "error" as const, error: "Network error. Please try again." }
-                : item
-            )
-          );
         }
-      }
+      };
+
+      // Start concurrent workers
+      await Promise.all(
+        Array.from({ length: Math.min(CONCURRENCY, compressed.length) }, () =>
+          processNext()
+        )
+      );
     },
     [setUser]
   );
@@ -251,39 +268,45 @@ export function AppShell({ children }: AppShellProps) {
 
     const successItems = multiScanItems.filter((i) => i.status === "success" && i.data);
 
-    for (const item of successItems) {
-      try {
-        const res = await fetch("/api/transactions", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
+    try {
+      const res = await fetch("/api/transactions/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          transactions: successItems.map((item) => ({
             amount: item.data!.amount,
             description: item.data!.description,
             type: item.data!.type,
             date: item.data!.date ? new Date(item.data!.date).toISOString() : new Date().toISOString(),
             categoryId: item.data!.categoryId,
-          }),
-        });
+          })),
+        }),
+      });
 
-        if (!res.ok) {
-          // Mark individual item as failed, continue with others
-          setMultiScanItems((prev) =>
-            prev.map((i) =>
-              i.id === item.id
-                ? { ...i, status: "error" as const, error: "Failed to save." }
-                : i
-            )
-          );
-        }
-      } catch {
+      if (!res.ok) {
+        // Mark all items as failed
+        const failedIds = new Set(successItems.map((i) => i.id));
         setMultiScanItems((prev) =>
           prev.map((i) =>
-            i.id === item.id
-              ? { ...i, status: "error" as const, error: "Network error." }
+            failedIds.has(i.id)
+              ? { ...i, status: "error" as const, error: "Failed to save." }
               : i
           )
         );
+        setIsSavingAll(false);
+        return;
       }
+    } catch {
+      const failedIds = new Set(successItems.map((i) => i.id));
+      setMultiScanItems((prev) =>
+        prev.map((i) =>
+          failedIds.has(i.id)
+            ? { ...i, status: "error" as const, error: "Network error." }
+            : i
+        )
+      );
+      setIsSavingAll(false);
+      return;
     }
 
     setIsSavingAll(false);


### PR DESCRIPTION
…and batch save

- Parallelize DB queries in scan API route (Promise.all for settings, scan count, categories)
- Process multi-scan uploads with concurrency limit of 2 instead of sequentially
- Compress all files in parallel before API calls
- Add /api/transactions/batch endpoint for atomic multi-transaction creation
- Use single batch POST in save-all instead of N sequential requests