### PR TITLE
feat(mcp): add MCP server for Claude Desktop integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ yarn-error.log*
 # claude code
 .claude-work/
 
+# mcp server
+mcp-server/node_modules/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -564,6 +564,45 @@ All notable development history for the Budget Tracker app.
 
 ---
 
+## 2026-02-28 — MCP Server (Claude Desktop Integration)
+
+### MCP Server
+- New **Model Context Protocol (MCP) server** for querying budget data directly from Claude Desktop using natural language
+- Runs locally via `tsx` over stdio — Claude Desktop starts and stops it automatically, no hosted server needed
+- Architecture: `Claude Desktop → (stdio) → MCP Server → Prisma → PostgreSQL`
+- User ID passed via `BUDGET_USER_ID` environment variable in the Claude Desktop config (no HTTP session needed)
+- Standalone `mcp-server/` package with its own `package.json` and `tsconfig.json` — isolated from the Next.js build
+
+### 8 Read-Only MCP Tools
+- **`get_spending_by_category`** — spending grouped by category for a given month, sorted by amount with percentages
+- **`get_top_expenses`** — largest individual expense transactions, optionally filtered by month (configurable limit, default 10)
+- **`get_monthly_summary`** — income, expenses, and net per month for the last N months (default 6, max 24)
+- **`get_spending_trends`** — compare spending between two months, broken down by category with absolute and percentage change
+- **`search_transactions`** — search and filter by description, category, amount range, type, and month; supports pagination and sorting
+- **`get_budget_overview`** — high-level monthly summary with total income, expenses, net, running balance, and transaction count
+- **`get_upcoming_bills`** — scheduled transactions due within N days (default 7, max 90), including overdue detection
+- **`get_category_list`** — all categories (default + custom) with type filtering; useful for finding category IDs for other tools
+
+### Shared Query Library
+- Created `src/lib/budget-queries.ts` — 8 reusable read-only query functions extracted from existing API routes
+- Created `src/lib/budget-query-types.ts` — TypeScript types for all query params and return values
+- **Dependency injection** pattern — all functions take `(prisma: PrismaClient, userId: string, params)` so both the MCP server and Next.js app can use their own Prisma instance
+- Query logic mirrors existing API routes: `get_spending_by_category` from `api/dashboard` lines 104–126, `get_monthly_summary` from lines 128–151, `search_transactions` from `api/transactions` lines 22–71, `get_upcoming_bills` from `api/bills/upcoming`, `get_category_list` from `api/categories` lines 13–26
+- Designed for reuse by a future in-app AI chat feature for end users
+
+### Files Added
+- `src/lib/budget-query-types.ts` — shared TypeScript types (params + return values for all 8 queries)
+- `src/lib/budget-queries.ts` — shared query functions with Prisma dependency injection
+- `mcp-server/package.json` — standalone package with `@modelcontextprotocol/sdk` dependency
+- `mcp-server/tsconfig.json` — standalone TypeScript config
+- `mcp-server/src/index.ts` — MCP server entry point registering 8 tools with Zod input schemas
+
+### Files Modified
+- `.gitignore` — added `mcp-server/node_modules/`
+- `tsconfig.json` — excluded `mcp-server/` from root type-checking to avoid conflicts with Next.js build
+
+---
+
 ## 2026-02-26 — Dashboard Bug Fixes
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A personal budget tracking app built with Next.js, TypeScript, and PostgreSQL. T
 - **Privacy Mode** — One-tap toggle to hide all financial amounts across the app, persisted per-user in the database
 - **Responsive** — Sidebar navigation on desktop, bottom navigation on mobile; labeled floating action buttons on mobile; modal bottom sheets with drag-to-dismiss on mobile, centered cards on desktop; keyboard-aware modals on iOS Safari
 - **Dynamic Favicon** — Auto-generated favicon matching the app logo
+- **MCP Server** — Local Model Context Protocol server for querying budget data from Claude Desktop; 8 read-only tools (spending by category, top expenses, monthly summary, spending trends, search transactions, budget overview, upcoming bills, category list); shared query library reusable for future in-app AI chat
 - **Design** — Warm paper-ledger aesthetic with Young Serif + Outfit fonts, Plus Jakarta Sans for currency amounts, amber accents, and Framer Motion animations
 
 ## Tech Stack
@@ -45,6 +46,7 @@ A personal budget tracking app built with Next.js, TypeScript, and PostgreSQL. T
 | Data Caching | TanStack Query |
 | Charts | Recharts |
 | OCR / AI | Google Gemini |
+| MCP Server | Model Context Protocol SDK |
 | Icons | Lucide React |
 | Animation | Framer Motion |
 
@@ -125,6 +127,91 @@ Open [http://localhost:3000](http://localhost:3000), register an account, and st
 | `pnpm db:seed` | Seed default categories + set admin role |
 | `pnpm db:studio` | Open Prisma Studio (database GUI) |
 
+## MCP Server (Claude Desktop Integration)
+
+The project includes a local [Model Context Protocol](https://modelcontextprotocol.io/) server that lets you query your budget data directly from Claude Desktop using natural language — e.g., "what's my biggest spending category?" or "how much did I spend on food this month?"
+
+### Architecture
+
+```
+Claude Desktop → (stdio) → MCP Server (local script) → Prisma → PostgreSQL
+```
+
+The MCP server is a standalone TypeScript script that runs locally via `tsx`. It is **not** a hosted server — Claude Desktop starts and stops it automatically.
+
+### Setup
+
+#### 1. Install MCP server dependencies
+
+```bash
+cd mcp-server && pnpm install && cd ..
+```
+
+#### 2. Generate Prisma client for the MCP server
+
+```bash
+cd mcp-server && npx prisma generate --schema=../prisma/schema.prisma && cd ..
+```
+
+#### 3. Find your user ID
+
+```bash
+pnpm db:studio
+```
+
+Open the `User` table in Prisma Studio and copy your user's `id` value.
+
+#### 4. Configure Claude Desktop
+
+Edit your Claude Desktop config file:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the following (replace the placeholder values):
+
+```json
+{
+  "mcpServers": {
+    "budgettracker": {
+      "command": "npx",
+      "args": ["tsx", "/absolute/path/to/budgettracker/mcp-server/src/index.ts"],
+      "env": {
+        "DATABASE_URL": "postgres://myuser:mypassword@localhost:5432/budgettracker-nextjs",
+        "BUDGET_USER_ID": "your-user-id-here"
+      }
+    }
+  }
+}
+```
+
+#### 5. Restart Claude Desktop
+
+Claude Desktop will automatically start the MCP server when you open a conversation. No manual startup needed.
+
+### Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `get_spending_by_category` | Spending grouped by category for a given month, with percentages |
+| `get_top_expenses` | Largest individual expense transactions, optionally filtered by month |
+| `get_monthly_summary` | Income, expenses, and net per month for the last N months |
+| `get_spending_trends` | Compare spending between two months — shows which categories increased or decreased |
+| `search_transactions` | Search and filter transactions by description, category, amount range, type, and month |
+| `get_budget_overview` | High-level monthly summary: income, expenses, net, running balance, transaction count |
+| `get_upcoming_bills` | Scheduled transactions (bills) due within N days, including overdue |
+| `get_category_list` | All categories (default + custom) — useful for finding category IDs |
+
+### Testing with MCP Inspector
+
+To verify tools work correctly before using in Claude Desktop:
+
+```bash
+BUDGET_USER_ID=your-user-id DATABASE_URL="your-database-url" npx @modelcontextprotocol/inspector npx tsx mcp-server/src/index.ts
+```
+
+This opens a web UI at `http://localhost:6274` where you can call each tool and inspect the results.
+
 ## Git Hooks
 
 This project uses **husky** + **lint-staged** to enforce code quality before code reaches the repository:
@@ -173,7 +260,15 @@ src/
 │   └── user-provider.tsx    # Reactive user info context (name, email, currency, role)
 ├── hooks/                   # TanStack Query hooks (use-transactions, use-categories)
 ├── lib/                     # Prisma client, auth, Gemini client, query client, utils, validations
+│   ├── budget-queries.ts    # Shared query functions (used by MCP server + future AI chat)
+│   └── budget-query-types.ts # TypeScript types for query params and return values
 └── types/                   # TypeScript type definitions
+
+mcp-server/                  # MCP server for Claude Desktop integration
+├── package.json             # Standalone dependencies (@modelcontextprotocol/sdk)
+├── tsconfig.json            # Standalone TypeScript config
+└── src/
+    └── index.ts             # Entry point — registers 8 read-only tools
 
 prisma/
 ├── schema.prisma            # Database schema

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "budgettracker-mcp-server",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1"
+  }
+}

--- a/mcp-server/pnpm-lock.yaml
+++ b/mcp-server/pnpm-lock.yaml
@@ -1,0 +1,774 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.1
+        version: 1.27.1(zod@4.3.6)
+
+packages:
+
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  express-rate-limit@8.2.1:
+    resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.3:
+    resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.0.1:
+    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@hono/node-server@1.19.9(hono@4.12.3)':
+    dependencies:
+      hono: 4.12.3
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.3)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.3
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  depd@2.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
+  express-rate-limit@8.2.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.0.1
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.3: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ip-address@10.0.1: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jose@6.1.3: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  ms@2.1.3: {}
+
+  negotiator@1.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.3.0: {}
+
+  pkce-challenge@5.0.1: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  require-from-string@2.0.2: {}
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  statuses@2.0.2: {}
+
+  toidentifier@1.0.1: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrappy@1.0.2: {}
+
+  zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod@4.3.6: {}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,237 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { PrismaClient } from "@prisma/client";
+import { z } from "zod";
+import {
+  getSpendingByCategory,
+  getTopExpenses,
+  getMonthlySummary,
+  getSpendingTrends,
+  searchTransactions,
+  getBudgetOverview,
+  getUpcomingBills,
+  getCategoryList,
+} from "../../src/lib/budget-queries.js";
+
+const userId = process.env.BUDGET_USER_ID;
+
+if (!userId) {
+  console.error("BUDGET_USER_ID environment variable is required");
+  process.exit(1);
+}
+
+const prisma = new PrismaClient();
+
+const server = new McpServer({
+  name: "budgettracker",
+  version: "1.0.0",
+});
+
+// --- Tool registrations ---
+
+server.tool(
+  "get_spending_by_category",
+  "Get spending grouped by category for a given month. Returns expense categories sorted by amount with percentages.",
+  {
+    month: z
+      .string()
+      .regex(/^\d{4}-\d{2}$/)
+      .optional()
+      .describe("Month in YYYY-MM format. Defaults to current month."),
+  },
+  async ({ month }) => {
+    const result = await getSpendingByCategory(prisma, userId, { month });
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "get_top_expenses",
+  "Get the largest individual expense transactions, optionally filtered by month.",
+  {
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe("Number of results. Defaults to 10."),
+    month: z
+      .string()
+      .regex(/^\d{4}-\d{2}$/)
+      .optional()
+      .describe("Month in YYYY-MM format. If omitted, returns all-time."),
+  },
+  async ({ limit, month }) => {
+    const result = await getTopExpenses(prisma, userId, { limit, month });
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "get_monthly_summary",
+  "Get income, expenses, and net for each of the last N months. Good for trend analysis.",
+  {
+    months: z
+      .number()
+      .int()
+      .min(1)
+      .max(24)
+      .optional()
+      .describe("Number of months to look back. Defaults to 6."),
+  },
+  async ({ months }) => {
+    const result = await getMonthlySummary(prisma, userId, { months });
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "get_spending_trends",
+  "Compare spending between two months, broken down by category. Shows which categories increased or decreased.",
+  {
+    currentMonth: z
+      .string()
+      .regex(/^\d{4}-\d{2}$/)
+      .describe("Current period in YYYY-MM format."),
+    previousMonth: z
+      .string()
+      .regex(/^\d{4}-\d{2}$/)
+      .describe("Comparison period in YYYY-MM format."),
+  },
+  async ({ currentMonth, previousMonth }) => {
+    const result = await getSpendingTrends(prisma, userId, {
+      currentMonth,
+      previousMonth,
+    });
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "search_transactions",
+  "Search and filter transactions by description, category, amount range, type, and month. Supports pagination and sorting.",
+  {
+    search: z
+      .string()
+      .optional()
+      .describe("Search term for transaction description (case-insensitive)."),
+    type: z
+      .enum(["INCOME", "EXPENSE"])
+      .optional()
+      .describe("Filter by transaction type."),
+    categoryId: z
+      .string()
+      .optional()
+      .describe("Filter by category ID. Use get_category_list to find IDs."),
+    month: z
+      .string()
+      .regex(/^\d{4}-\d{2}$/)
+      .optional()
+      .describe("Filter by month in YYYY-MM format."),
+    amountMin: z.number().optional().describe("Minimum amount filter."),
+    amountMax: z.number().optional().describe("Maximum amount filter."),
+    sortBy: z
+      .enum(["date", "amount"])
+      .optional()
+      .describe("Sort field. Defaults to date."),
+    sortDir: z
+      .enum(["asc", "desc"])
+      .optional()
+      .describe("Sort direction. Defaults to desc."),
+    page: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe("Page number. Defaults to 1."),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("Results per page. Defaults to 20."),
+  },
+  async (params) => {
+    const result = await searchTransactions(prisma, userId, params);
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "get_budget_overview",
+  "Get a high-level monthly summary: total income, expenses, net, running balance, and transaction count.",
+  {
+    month: z
+      .string()
+      .regex(/^\d{4}-\d{2}$/)
+      .optional()
+      .describe("Month in YYYY-MM format. Defaults to current month."),
+  },
+  async ({ month }) => {
+    const result = await getBudgetOverview(prisma, userId, { month });
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "get_upcoming_bills",
+  "Get scheduled transactions (bills) due within N days. Shows overdue bills too.",
+  {
+    days: z
+      .number()
+      .int()
+      .min(1)
+      .max(90)
+      .optional()
+      .describe("Number of days to look ahead. Defaults to 7."),
+  },
+  async ({ days }) => {
+    const result = await getUpcomingBills(prisma, userId, { days });
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "get_category_list",
+  "List all budget categories (both default and custom). Useful for finding category IDs to use with other tools.",
+  {
+    type: z
+      .enum(["INCOME", "EXPENSE"])
+      .optional()
+      .describe("Filter by category type."),
+  },
+  async ({ type }) => {
+    const result = await getCategoryList(prisma, userId, { type });
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+    };
+  }
+);
+
+// --- Start server ---
+
+const main = async () => {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+};
+
+main().catch((err) => {
+  console.error("MCP server failed to start:", err);
+  process.exit(1);
+});

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "paths": {
+      "@/*": ["../src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/src/lib/budget-queries.ts
+++ b/src/lib/budget-queries.ts
@@ -1,0 +1,451 @@
+import type {
+  PrismaClient,
+  SpendingByCategoryParams,
+  CategorySpending,
+  TopExpensesParams,
+  TopExpense,
+  MonthlySummaryParams,
+  MonthSummary,
+  SpendingTrendsParams,
+  SpendingTrends,
+  SearchTransactionsParams,
+  SearchTransactionsResult,
+  BudgetOverviewParams,
+  BudgetOverview,
+  UpcomingBillsParams,
+  UpcomingBillsResult,
+  CategoryListParams,
+  CategoryItem,
+  DateRange,
+} from "./budget-query-types";
+
+/** Parse "YYYY-MM" into a start/end date range for that month */
+const parseMonth = (month: string): DateRange => {
+  const [year, m] = month.split("-").map(Number);
+  return {
+    startDate: new Date(year, m - 1, 1),
+    endDate: new Date(year, m, 0, 23, 59, 59, 999),
+  };
+};
+
+/** Get current month as "YYYY-MM" */
+const currentMonth = (): string => {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+};
+
+/**
+ * Spending grouped by category for a given month.
+ * Returns expense categories sorted by amount (highest first).
+ */
+export const getSpendingByCategory = async (
+  prisma: PrismaClient,
+  userId: string,
+  params: SpendingByCategoryParams = {}
+): Promise<CategorySpending[]> => {
+  const { startDate, endDate } = parseMonth(params.month ?? currentMonth());
+
+  const transactions = await prisma.transaction.findMany({
+    where: {
+      userId,
+      type: "EXPENSE",
+      date: { gte: startDate, lte: endDate },
+    },
+    include: { category: true },
+  });
+
+  const categoryMap = new Map<
+    string,
+    { name: string; color: string; icon: string; amount: number }
+  >();
+
+  for (const t of transactions) {
+    const existing = categoryMap.get(t.categoryId);
+    if (existing) {
+      existing.amount += t.amount;
+    } else {
+      categoryMap.set(t.categoryId, {
+        name: t.category.name,
+        color: t.category.color,
+        icon: t.category.icon,
+        amount: t.amount,
+      });
+    }
+  }
+
+  const totalExpenses = transactions.reduce((sum, t) => sum + t.amount, 0);
+
+  return Array.from(categoryMap.entries())
+    .sort((a, b) => b[1].amount - a[1].amount)
+    .map(([categoryId, item]) => ({
+      categoryId,
+      ...item,
+      percentage:
+        totalExpenses > 0
+          ? Math.round((item.amount / totalExpenses) * 100)
+          : 0,
+    }));
+};
+
+/**
+ * Largest individual expense transactions.
+ */
+export const getTopExpenses = async (
+  prisma: PrismaClient,
+  userId: string,
+  params: TopExpensesParams = {}
+): Promise<TopExpense[]> => {
+  const limit = params.limit ?? 10;
+
+  const where: Record<string, unknown> = { userId, type: "EXPENSE" };
+
+  if (params.month) {
+    const { startDate, endDate } = parseMonth(params.month);
+    where.date = { gte: startDate, lte: endDate };
+  }
+
+  const transactions = await prisma.transaction.findMany({
+    where,
+    include: { category: true },
+    orderBy: { amount: "desc" },
+    take: limit,
+  });
+
+  return transactions.map((t) => ({
+    id: t.id,
+    amount: t.amount,
+    description: t.description,
+    date: t.date.toISOString(),
+    categoryName: t.category.name,
+    categoryIcon: t.category.icon,
+  }));
+};
+
+/**
+ * Income/expenses/net per month for the last N months.
+ */
+export const getMonthlySummary = async (
+  prisma: PrismaClient,
+  userId: string,
+  params: MonthlySummaryParams = {}
+): Promise<MonthSummary[]> => {
+  const months = params.months ?? 6;
+  const now = new Date();
+  const startDate = new Date(now.getFullYear(), now.getMonth() - (months - 1), 1);
+  const endDate = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+
+  const transactions = await prisma.transaction.findMany({
+    where: {
+      userId,
+      date: { gte: startDate, lte: endDate },
+    },
+    select: { amount: true, type: true, date: true },
+  });
+
+  const monthNames = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+
+  const result: MonthSummary[] = [];
+
+  for (let i = months - 1; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const monthKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    const monthLabel = `${monthNames[d.getMonth()]} ${d.getFullYear()}`;
+
+    const monthTx = transactions.filter((t) => {
+      const td = new Date(t.date);
+      return (
+        `${td.getFullYear()}-${String(td.getMonth() + 1).padStart(2, "0")}` ===
+        monthKey
+      );
+    });
+
+    const income = monthTx
+      .filter((t) => t.type === "INCOME")
+      .reduce((sum, t) => sum + t.amount, 0);
+
+    const expenses = monthTx
+      .filter((t) => t.type === "EXPENSE")
+      .reduce((sum, t) => sum + t.amount, 0);
+
+    result.push({
+      month: monthLabel,
+      income,
+      expenses,
+      net: income - expenses,
+    });
+  }
+
+  return result;
+};
+
+/**
+ * Compare spending between two months, broken down by category.
+ */
+export const getSpendingTrends = async (
+  prisma: PrismaClient,
+  userId: string,
+  params: SpendingTrendsParams
+): Promise<SpendingTrends> => {
+  const [currentSpending, previousSpending] = await Promise.all([
+    getSpendingByCategory(prisma, userId, { month: params.currentMonth }),
+    getSpendingByCategory(prisma, userId, { month: params.previousMonth }),
+  ]);
+
+  const currentTotal = currentSpending.reduce((sum, c) => sum + c.amount, 0);
+  const previousTotal = previousSpending.reduce((sum, c) => sum + c.amount, 0);
+  const totalChange = currentTotal - previousTotal;
+
+  // Build a unified category map
+  const categoryNames = new Set<string>();
+  for (const c of currentSpending) categoryNames.add(c.name);
+  for (const c of previousSpending) categoryNames.add(c.name);
+
+  const byCategory = Array.from(categoryNames).map((name) => {
+    const curr = currentSpending.find((c) => c.name === name)?.amount ?? 0;
+    const prev = previousSpending.find((c) => c.name === name)?.amount ?? 0;
+    const change = curr - prev;
+    return {
+      name,
+      current: curr,
+      previous: prev,
+      change,
+      changePercent: prev > 0 ? Math.round((change / prev) * 100) : null,
+    };
+  });
+
+  // Sort by absolute change descending
+  byCategory.sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
+
+  return {
+    currentTotal,
+    previousTotal,
+    totalChange,
+    totalChangePercent:
+      previousTotal > 0
+        ? Math.round((totalChange / previousTotal) * 100)
+        : null,
+    byCategory,
+  };
+};
+
+/**
+ * Search transactions with filters, pagination, and sorting.
+ */
+export const searchTransactions = async (
+  prisma: PrismaClient,
+  userId: string,
+  params: SearchTransactionsParams = {}
+): Promise<SearchTransactionsResult> => {
+  const page = params.page ?? 1;
+  const limit = params.limit ?? 20;
+
+  const where: Record<string, unknown> = { userId };
+
+  if (params.type) {
+    where.type = params.type;
+  }
+
+  if (params.month) {
+    const [year, m] = params.month.split("-").map(Number);
+    where.date = {
+      gte: new Date(year, m - 1, 1),
+      lt: new Date(year, m, 1),
+    };
+  }
+
+  if (params.categoryId) {
+    where.categoryId = params.categoryId;
+  }
+
+  if (params.amountMin !== undefined || params.amountMax !== undefined) {
+    const amountFilter: Record<string, number> = {};
+    if (params.amountMin !== undefined) amountFilter.gte = params.amountMin;
+    if (params.amountMax !== undefined) amountFilter.lte = params.amountMax;
+    where.amount = amountFilter;
+  }
+
+  if (params.search) {
+    where.description = { contains: params.search, mode: "insensitive" };
+  }
+
+  const direction = params.sortDir === "asc" ? "asc" : "desc";
+  const orderBy =
+    params.sortBy === "amount"
+      ? [
+          { amount: direction as "asc" | "desc" },
+          { date: "desc" as const },
+          { id: "asc" as const },
+        ]
+      : [
+          { date: direction as "asc" | "desc" },
+          { createdAt: "desc" as const },
+          { id: "asc" as const },
+        ];
+
+  const [transactions, total] = await Promise.all([
+    prisma.transaction.findMany({
+      where,
+      include: { category: true },
+      orderBy,
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.transaction.count({ where }),
+  ]);
+
+  return {
+    transactions: transactions.map((t) => ({
+      id: t.id,
+      amount: t.amount,
+      description: t.description,
+      type: t.type as "INCOME" | "EXPENSE",
+      date: t.date.toISOString(),
+      categoryName: t.category.name,
+      categoryIcon: t.category.icon,
+      categoryColor: t.category.color,
+    })),
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+    },
+  };
+};
+
+/**
+ * High-level monthly summary with running balance.
+ */
+export const getBudgetOverview = async (
+  prisma: PrismaClient,
+  userId: string,
+  params: BudgetOverviewParams = {}
+): Promise<BudgetOverview> => {
+  const monthStr = params.month ?? currentMonth();
+  const { startDate, endDate } = parseMonth(monthStr);
+
+  const [transactions, runningIncome, runningExpenses] = await Promise.all([
+    prisma.transaction.findMany({
+      where: {
+        userId,
+        date: { gte: startDate, lte: endDate },
+      },
+      select: { amount: true, type: true },
+    }),
+
+    prisma.transaction.aggregate({
+      where: { userId, type: "INCOME", date: { lte: endDate } },
+      _sum: { amount: true },
+    }),
+
+    prisma.transaction.aggregate({
+      where: { userId, type: "EXPENSE", date: { lte: endDate } },
+      _sum: { amount: true },
+    }),
+  ]);
+
+  const totalIncome = transactions
+    .filter((t) => t.type === "INCOME")
+    .reduce((sum, t) => sum + t.amount, 0);
+
+  const totalExpenses = transactions
+    .filter((t) => t.type === "EXPENSE")
+    .reduce((sum, t) => sum + t.amount, 0);
+
+  const runningBalance =
+    (runningIncome._sum.amount ?? 0) - (runningExpenses._sum.amount ?? 0);
+
+  return {
+    month: monthStr,
+    totalIncome,
+    totalExpenses,
+    net: totalIncome - totalExpenses,
+    runningBalance,
+    transactionCount: transactions.length,
+  };
+};
+
+/**
+ * Scheduled transactions due within N days.
+ */
+export const getUpcomingBills = async (
+  prisma: PrismaClient,
+  userId: string,
+  params: UpcomingBillsParams = {}
+): Promise<UpcomingBillsResult> => {
+  const days = params.days ?? 7;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const cutoff = new Date(today);
+  cutoff.setDate(cutoff.getDate() + days);
+
+  const bills = await prisma.scheduledTransaction.findMany({
+    where: {
+      userId,
+      isActive: true,
+      nextDueDate: { lte: cutoff },
+    },
+    include: { category: true },
+    orderBy: { nextDueDate: "asc" },
+  });
+
+  const upcomingBills = bills.map((bill) => {
+    const dueDate = new Date(bill.nextDueDate);
+    dueDate.setHours(0, 0, 0, 0);
+
+    return {
+      id: bill.id,
+      description: bill.description || bill.category.name,
+      categoryName: bill.category.name,
+      categoryIcon: bill.category.icon,
+      categoryColor: bill.category.color,
+      amount: bill.amount,
+      dueDate: bill.nextDueDate.toISOString(),
+      isOverdue: dueDate < today,
+    };
+  });
+
+  const totalAmount = upcomingBills.reduce((sum, b) => sum + b.amount, 0);
+
+  return {
+    count: upcomingBills.length,
+    totalAmount,
+    bills: upcomingBills,
+  };
+};
+
+/**
+ * All categories (default + custom) for the user.
+ */
+export const getCategoryList = async (
+  prisma: PrismaClient,
+  userId: string,
+  params: CategoryListParams = {}
+): Promise<CategoryItem[]> => {
+  const where: Record<string, unknown> = {
+    OR: [{ isDefault: true }, { userId }],
+  };
+
+  if (params.type) {
+    where.type = params.type;
+  }
+
+  const categories = await prisma.category.findMany({
+    where,
+    orderBy: [{ isDefault: "desc" }, { name: "asc" }],
+  });
+
+  return categories.map((c) => ({
+    id: c.id,
+    name: c.name,
+    type: c.type as "INCOME" | "EXPENSE",
+    icon: c.icon,
+    color: c.color,
+    isDefault: c.isDefault,
+  }));
+};

--- a/src/lib/budget-query-types.ts
+++ b/src/lib/budget-query-types.ts
@@ -1,0 +1,185 @@
+import type { PrismaClient } from "@prisma/client";
+
+// Re-export PrismaClient type for convenience
+export type { PrismaClient };
+
+// Common filter types
+export type TransactionType = "INCOME" | "EXPENSE";
+
+export interface DateRange {
+  startDate: Date;
+  endDate: Date;
+}
+
+// --- get_spending_by_category ---
+
+export interface SpendingByCategoryParams {
+  /** Format: YYYY-MM. Defaults to current month */
+  month?: string;
+}
+
+export interface CategorySpending {
+  categoryId: string;
+  name: string;
+  color: string;
+  icon: string;
+  amount: number;
+  percentage: number;
+}
+
+// --- get_top_expenses ---
+
+export interface TopExpensesParams {
+  /** Number of results to return. Defaults to 10 */
+  limit?: number;
+  /** Format: YYYY-MM. If omitted, returns all-time */
+  month?: string;
+}
+
+export interface TopExpense {
+  id: string;
+  amount: number;
+  description: string;
+  date: string;
+  categoryName: string;
+  categoryIcon: string;
+}
+
+// --- get_monthly_summary ---
+
+export interface MonthlySummaryParams {
+  /** Number of months to look back. Defaults to 6 */
+  months?: number;
+}
+
+export interface MonthSummary {
+  month: string;
+  income: number;
+  expenses: number;
+  net: number;
+}
+
+// --- get_spending_trends ---
+
+export interface SpendingTrendsParams {
+  /** Format: YYYY-MM (current period) */
+  currentMonth: string;
+  /** Format: YYYY-MM (comparison period) */
+  previousMonth: string;
+}
+
+export interface CategoryTrend {
+  name: string;
+  current: number;
+  previous: number;
+  change: number;
+  changePercent: number | null;
+}
+
+export interface SpendingTrends {
+  currentTotal: number;
+  previousTotal: number;
+  totalChange: number;
+  totalChangePercent: number | null;
+  byCategory: CategoryTrend[];
+}
+
+// --- search_transactions ---
+
+export interface SearchTransactionsParams {
+  /** Search term for description (case-insensitive) */
+  search?: string;
+  /** Filter by type */
+  type?: TransactionType;
+  /** Filter by category ID */
+  categoryId?: string;
+  /** Format: YYYY-MM */
+  month?: string;
+  /** Minimum amount */
+  amountMin?: number;
+  /** Maximum amount */
+  amountMax?: number;
+  /** Sort field. Defaults to "date" */
+  sortBy?: "date" | "amount";
+  /** Sort direction. Defaults to "desc" */
+  sortDir?: "asc" | "desc";
+  /** Page number. Defaults to 1 */
+  page?: number;
+  /** Results per page. Defaults to 20 */
+  limit?: number;
+}
+
+export interface SearchTransactionsResult {
+  transactions: Array<{
+    id: string;
+    amount: number;
+    description: string;
+    type: TransactionType;
+    date: string;
+    categoryName: string;
+    categoryIcon: string;
+    categoryColor: string;
+  }>;
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+// --- get_budget_overview ---
+
+export interface BudgetOverviewParams {
+  /** Format: YYYY-MM. Defaults to current month */
+  month?: string;
+}
+
+export interface BudgetOverview {
+  month: string;
+  totalIncome: number;
+  totalExpenses: number;
+  net: number;
+  runningBalance: number;
+  transactionCount: number;
+}
+
+// --- get_upcoming_bills ---
+
+export interface UpcomingBillsParams {
+  /** Number of days to look ahead. Defaults to 7 */
+  days?: number;
+}
+
+export interface UpcomingBill {
+  id: string;
+  description: string;
+  categoryName: string;
+  categoryIcon: string;
+  categoryColor: string;
+  amount: number;
+  dueDate: string;
+  isOverdue: boolean;
+}
+
+export interface UpcomingBillsResult {
+  count: number;
+  totalAmount: number;
+  bills: UpcomingBill[];
+}
+
+// --- get_category_list ---
+
+export interface CategoryListParams {
+  /** Filter by type */
+  type?: TransactionType;
+}
+
+export interface CategoryItem {
+  id: string;
+  name: string;
+  type: TransactionType;
+  icon: string;
+  color: string;
+  isDefault: boolean;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "mcp-server"]
 }


### PR DESCRIPTION
## Summary
- Add a local MCP (Model Context Protocol) server so budget data can be queried from Claude Desktop using natural language (e.g., "what's my biggest spending category?")
- Extract 8 read-only query functions into a shared library (`src/lib/budget-queries.ts`) with dependency injection, designed for reuse by a future in-app AI chat feature
- MCP server runs locally via `tsx` over stdio — Claude Desktop starts/stops it automatically

## MCP Tools (8 total, all read-only)

| Tool | Description |
|---|---|
| `get_spending_by_category` | Spending grouped by category for a given month, with percentages |
| `get_top_expenses` | Largest individual expense transactions, optionally filtered by month |
| `get_monthly_summary` | Income, expenses, and net per month for the last N months |
| `get_spending_trends` | Compare spending between two months by category |
| `search_transactions` | Search/filter by description, category, amount, type, month with pagination |
| `get_budget_overview` | Monthly summary: income, expenses, net, running balance, transaction count |
| `get_upcoming_bills` | Scheduled transactions due within N days, including overdue |
| `get_category_list` | All categories (default + custom) with type filtering |

## Architecture

```
Claude Desktop → (stdio) → MCP Server (local script) → Prisma → PostgreSQL
```

## Files Added
- `src/lib/budget-query-types.ts` — shared TypeScript types for all query params/returns
- `src/lib/budget-queries.ts` — 8 reusable query functions extracted from existing API routes
- `mcp-server/package.json` — standalone package with `@modelcontextprotocol/sdk`
- `mcp-server/tsconfig.json` — standalone TypeScript config
- `mcp-server/src/index.ts` — MCP server entry point with 8 tool registrations

## Files Modified
- `.gitignore` — added `mcp-server/node_modules/`
- `tsconfig.json` — excluded `mcp-server/` from root type-checking
- `README.md` — added MCP server setup guide and tools reference
- `CHANGELOG.md` — added detailed entry for this feature

## Test plan
- [x] `pnpm lint` — no errors
- [x] `pnpm type-check` — no errors
- [x] MCP server starts and responds to `initialize` handshake
- [x] `tools/list` returns all 8 tools with correct schemas
- [x] Tested all tools via MCP Inspector against local database