### PR TITLE
fix(receipts): clamp scan dates to prevent wrong year from POS systems

### DIFF
--- a/src/app/api/receipts/breakdown/route.ts
+++ b/src/app/api/receipts/breakdown/route.ts
@@ -33,31 +33,16 @@ const MAX_FILE_SIZE = 4 * 1024 * 1024; // 4 MB
 const stripCodeFences = (text: string): string =>
   text.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "");
 
-/** Fix receipt date when POS systems print an obviously wrong year.
- *  Extracts the date portion first to handle both "YYYY-MM-DD" and full ISO timestamps.
- *  Only corrects when the month/day are close to today (within 3 days) but the year
- *  differs — the clear signature of a POS with a misconfigured clock.
- *  Legitimate historical receipts (different month/day) are never modified. */
-const clampReceiptDate = (dateStr: string, fallback: string): string => {
+/** Normalize receipt date and flag when the year differs from today.
+ *  Extracts the date portion to handle both "YYYY-MM-DD" and full ISO timestamps.
+ *  Never modifies the date — returns a warning flag instead so the UI can
+ *  prompt the user to confirm or correct it. */
+const checkReceiptDate = (dateStr: string, fallback: string): { date: string; dateWarning: boolean } => {
   const dateOnly = dateStr.slice(0, 10); // normalize "2024-03-14T13:45" → "2024-03-14"
   const parsed = new Date(dateOnly + "T00:00:00");
-  if (isNaN(parsed.getTime())) return fallback;
-  const today = new Date(fallback + "T00:00:00");
-  const parsedYear = parsed.getFullYear();
-  const todayYear = today.getFullYear();
-  if (parsedYear === todayYear) return dateOnly;
-  // Check if month/day are within 3 days of today (same year context)
-  const sameYearDate = new Date(
-    `${todayYear}-${dateOnly.slice(5)}T00:00:00`
-  );
-  if (isNaN(sameYearDate.getTime())) return dateOnly;
-  const dayDiff = Math.abs(sameYearDate.getTime() - today.getTime());
-  const threeDaysMs = 3 * 24 * 60 * 60 * 1000;
-  if (dayDiff <= threeDaysMs) {
-    // Month/day match today but year is wrong → POS year error
-    return `${todayYear}-${dateOnly.slice(5)}`;
-  }
-  return dateOnly;
+  if (isNaN(parsed.getTime())) return { date: fallback, dateWarning: false };
+  const todayYear = new Date(fallback + "T00:00:00").getFullYear();
+  return { date: dateOnly, dateWarning: parsed.getFullYear() !== todayYear };
 };
 
 export async function POST(request: Request) {
@@ -255,8 +240,9 @@ RULES:
       );
     }
 
-    // Clamp date if POS printed a wrong year
-    result.data.date = clampReceiptDate(result.data.date, todayStr);
+    // Normalize date and flag suspicious year for the UI
+    const { date: normalizedDate, dateWarning } = checkReceiptDate(result.data.date, todayStr);
+    result.data.date = normalizedDate;
 
     // Verify each categoryId exists, fall back to "Other" if not
     const categoryIds = new Set(categories.map((c) => c.id));
@@ -272,7 +258,7 @@ RULES:
     // Log 1 scan credit for the breakdown (fire-and-forget)
     prisma.scanLog.create({ data: { userId } }).catch(() => {});
 
-    return NextResponse.json(result.data);
+    return NextResponse.json({ ...result.data, dateWarning });
   } catch {
     return NextResponse.json(
       { error: "Failed to break down receipt. Please try again." },

--- a/src/app/api/receipts/scan/route.ts
+++ b/src/app/api/receipts/scan/route.ts
@@ -35,31 +35,16 @@ const MAX_FILE_SIZE = 4 * 1024 * 1024; // 4 MB
 const stripCodeFences = (text: string): string =>
   text.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "");
 
-/** Fix receipt date when POS systems print an obviously wrong year.
- *  Extracts the date portion first to handle both "YYYY-MM-DD" and full ISO timestamps.
- *  Only corrects when the month/day are close to today (within 3 days) but the year
- *  differs — the clear signature of a POS with a misconfigured clock.
- *  Legitimate historical receipts (different month/day) are never modified. */
-const clampReceiptDate = (dateStr: string, fallback: string): string => {
+/** Normalize receipt date and flag when the year differs from today.
+ *  Extracts the date portion to handle both "YYYY-MM-DD" and full ISO timestamps.
+ *  Never modifies the date — returns a warning flag instead so the UI can
+ *  prompt the user to confirm or correct it. */
+const checkReceiptDate = (dateStr: string, fallback: string): { date: string; dateWarning: boolean } => {
   const dateOnly = dateStr.slice(0, 10); // normalize "2024-03-14T13:45" → "2024-03-14"
   const parsed = new Date(dateOnly + "T00:00:00");
-  if (isNaN(parsed.getTime())) return fallback;
-  const today = new Date(fallback + "T00:00:00");
-  const parsedYear = parsed.getFullYear();
-  const todayYear = today.getFullYear();
-  if (parsedYear === todayYear) return dateOnly;
-  // Check if month/day are within 3 days of today (same year context)
-  const sameYearDate = new Date(
-    `${todayYear}-${dateOnly.slice(5)}T00:00:00`
-  );
-  if (isNaN(sameYearDate.getTime())) return dateOnly;
-  const dayDiff = Math.abs(sameYearDate.getTime() - today.getTime());
-  const threeDaysMs = 3 * 24 * 60 * 60 * 1000;
-  if (dayDiff <= threeDaysMs) {
-    // Month/day match today but year is wrong → POS year error
-    return `${todayYear}-${dateOnly.slice(5)}`;
-  }
-  return dateOnly;
+  if (isNaN(parsed.getTime())) return { date: fallback, dateWarning: false };
+  const todayYear = new Date(fallback + "T00:00:00").getFullYear();
+  return { date: dateOnly, dateWarning: parsed.getFullYear() !== todayYear };
 };
 
 export async function POST(request: Request) {
@@ -259,15 +244,9 @@ or when multiCategory is true:
       );
     }
 
-    // Clamp date if POS printed a wrong year
-    result.data.date = clampReceiptDate(result.data.date, todayStr);
-    if (result.data.breakdown) {
-      for (const item of result.data.breakdown) {
-        if ("date" in item && typeof item.date === "string") {
-          item.date = clampReceiptDate(item.date, todayStr);
-        }
-      }
-    }
+    // Normalize date and flag suspicious year for the UI
+    const { date: normalizedDate, dateWarning } = checkReceiptDate(result.data.date, todayStr);
+    result.data.date = normalizedDate;
 
     // Verify the categoryId actually exists in user's categories
     const categoryIds = new Set(categories.map((c) => c.id));
@@ -290,7 +269,7 @@ or when multiCategory is true:
     // Log successful scan for monthly limit tracking (fire-and-forget)
     prisma.scanLog.create({ data: { userId } }).catch(() => {});
 
-    return NextResponse.json(result.data);
+    return NextResponse.json({ ...result.data, dateWarning });
   } catch {
     return NextResponse.json(
       { error: "Failed to scan receipt. Please try again." },

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -122,6 +122,7 @@ export function AppShell({ children }: AppShellProps) {
             categoryId: data.categoryId,
             multiCategory: data.multiCategory,
             breakdown: data.breakdown,
+            dateWarning: data.dateWarning,
           },
           imageFile: compressed,
         },
@@ -215,6 +216,7 @@ export function AppShell({ children }: AppShellProps) {
                         categoryId: data.categoryId,
                         multiCategory: data.multiCategory,
                         breakdown: data.breakdown,
+                        dateWarning: data.dateWarning,
                       },
                       imageFile: file instanceof File ? file : undefined,
                     }
@@ -288,7 +290,8 @@ export function AppShell({ children }: AppShellProps) {
         categoryId: string;
         description: string;
         lineItems: Array<{ name: string; amount: number }>;
-      }>
+      }>,
+      dateWarning?: boolean
     ) => {
       const receiptGroupId = crypto.randomUUID();
 
@@ -303,6 +306,7 @@ export function AppShell({ children }: AppShellProps) {
           date,
           categoryId: bi.categoryId,
           receiptGroupId,
+          dateWarning,
           receiptBreakdown: {
             total: bi.amount,
             items: bi.lineItems.map((li) => ({
@@ -335,7 +339,8 @@ export function AppShell({ children }: AppShellProps) {
         id,
         item.fileName,
         item.data.date ?? new Date().toISOString(),
-        item.data.breakdown
+        item.data.breakdown,
+        item.data.dateWarning
       );
       return;
     }
@@ -367,7 +372,7 @@ export function AppShell({ children }: AppShellProps) {
         return;
       }
 
-      expandBreakdown(id, item.fileName, withLocalTime(data.date), data.items);
+      expandBreakdown(id, item.fileName, withLocalTime(data.date), data.items, data.dateWarning);
 
       // Increment local scan count (breakdown = 1 additional credit)
       setUser((prev) => ({ scansUsedThisMonth: prev.scansUsedThisMonth + 1 }));
@@ -721,6 +726,7 @@ export function AppShell({ children }: AppShellProps) {
                   date: editItem.data.date,
                   categoryId: editItem.data.categoryId,
                 }}
+                dateWarning={editItem.data.dateWarning}
                 onSubmit={handleMultiScanEditSubmit}
                 onCancel={() => setEditingItemId(null)}
               />

--- a/src/components/multi-scan-review.tsx
+++ b/src/components/multi-scan-review.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { Pencil, Trash2, AlertCircle, CheckCircle2, Loader2, Rows3 } from "lucide-react";
 import { CategoryIcon } from "@/components/ui/icon-map";
-import { formatCurrency } from "@/lib/utils";
+import { formatCurrency, cn } from "@/lib/utils";
 import { useUser } from "@/components/user-provider";
 import type { Category, MultiScanItem } from "@/types";
 
@@ -143,6 +143,7 @@ export function MultiScanReview({
             ? new Date(item.data.date).toLocaleDateString("en-PH", {
                 month: "short",
                 day: "numeric",
+                ...(item.data.dateWarning && { year: "numeric" }),
               })
             : "";
           const canItemize = !!item.imageFile && !item.parentId && !!item.data?.multiCategory;
@@ -191,7 +192,12 @@ export function MultiScanReview({
                     <span className="text-xs text-warm-200">&middot;</span>
                   )}
                   {formattedDate && (
-                    <span className="text-xs text-warm-400">{formattedDate}</span>
+                    <span className={cn("text-xs", item.data?.dateWarning ? "text-amber-600 font-medium" : "text-warm-400")}>
+                      {item.data?.dateWarning && "⚠ "}{formattedDate}
+                      {item.data?.dateWarning && (
+                        <span className="text-[10px] text-amber-500 ml-1">(check year)</span>
+                      )}
+                    </span>
                   )}
                 </div>
               </div>

--- a/src/components/transactions/transaction-form.tsx
+++ b/src/components/transactions/transaction-form.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { motion, AnimatePresence } from "framer-motion";
-import { ArrowLeft, CalendarDays, ChevronRight, Plus, Trash2 } from "lucide-react";
+import { AlertCircle, ArrowLeft, CalendarDays, ChevronRight, Plus, Trash2 } from "lucide-react";
 import { transactionSchema, type TransactionInput } from "@/lib/validations";
 import { formatDateInput, getCurrencySymbol, cn } from "@/lib/utils";
 import { CategoryIcon } from "@/components/ui/icon-map";
@@ -24,6 +24,8 @@ export interface InitialTransactionData {
 interface TransactionFormProps {
   transaction?: TransactionWithCategory | null;
   initialData?: InitialTransactionData;
+  /** When true, shows a warning that the receipt date year looks suspicious (possible POS error) */
+  dateWarning?: boolean;
   onSubmit: (data: TransactionInput) => Promise<void>;
   onCancel: () => void;
   onDelete?: () => void;
@@ -58,7 +60,7 @@ const slideVariants = {
 
 const QUICK_CATEGORY_COUNT = 4;
 
-export function TransactionForm({ transaction, initialData, onSubmit, onCancel, onDelete }: TransactionFormProps) {
+export function TransactionForm({ transaction, initialData, dateWarning, onSubmit, onCancel, onDelete }: TransactionFormProps) {
   const { user } = useUser();
   const [showCategoryPicker, setShowCategoryPicker] = useState(false);
   const [displayAmount, setDisplayAmount] = useState<string>(() => {
@@ -461,6 +463,15 @@ export function TransactionForm({ transaction, initialData, onSubmit, onCancel, 
                   onChange={(e) => setValue("date", e.target.value)}
                   className="w-full mt-2.5 px-4 py-2.5 rounded-xl border border-cream-300 bg-cream-50/50 text-warm-700 text-sm focus:outline-none focus:ring-2 focus:ring-amber/30 focus:border-amber transition-all appearance-none [&::-webkit-calendar-picker-indicator]:opacity-60"
                 />
+              )}
+
+              {dateWarning && dateMode !== "today" && dateMode !== "yesterday" && (
+                <div className="flex items-start gap-2 mt-2.5 p-3 rounded-xl bg-amber-50 border border-amber-200">
+                  <AlertCircle className="w-4 h-4 text-amber-600 shrink-0 mt-0.5" />
+                  <p className="text-xs text-amber-700">
+                    The receipt date year looks incorrect (possible POS error). Please verify the date is correct or tap <strong>Today</strong> to use today&apos;s date.
+                  </p>
+                </div>
               )}
 
               {errors.date && (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -96,6 +96,8 @@ export interface MultiScanItem {
       description: string;
       lineItems: Array<{ name: string; amount: number }>;
     }>;
+    /** True when the receipt date year differs from the current year (possible POS error) */
+    dateWarning?: boolean;
   };
   error?: string;
   /** Compressed image kept in memory for breakdown requests */


### PR DESCRIPTION
## Summary
- Some merchant POS systems print incorrect years on receipts (e.g. 2024 instead of 2026), causing Gemini to extract wrong transaction dates
- Added server-side date clamping in both `/api/receipts/scan` and `/api/receipts/breakdown` — if the extracted date is more than 6 months from today, it defaults to today's date
- Improved Gemini prompts to explicitly prioritize transaction/purchase dates and ignore regulatory dates (PTU, BIR, "Date of Issuance")

## Test plan
- [ ] Scan a receipt with a correct date — should preserve the receipt date as-is
- [ ] Scan a receipt with a wrong year (e.g. 2024) — should auto-correct to today's date
- [ ] Verify multi-scan breakdown also clamps dates correctly