### PR TITLE
feat(dashboard): show label chips on recent transactions

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -443,9 +443,33 @@ export default function DashboardPage() {
                                 </span>
                               )}
                             </div>
-                            <p className="text-xs text-warm-300 truncate">
-                              {tx.category.name}
-                            </p>
+                            <div className="flex items-center gap-1 min-w-0">
+                              <p className="text-xs text-warm-300 truncate">
+                                {tx.category.name}
+                              </p>
+                              {tx.labels && tx.labels.length > 0 && (
+                                <>
+                                  <span className="text-warm-200">&middot;</span>
+                                  {tx.labels.slice(0, 2).map((tl) => (
+                                    <span
+                                      key={tl.id}
+                                      className="inline-flex items-center gap-0.5 text-[10px] font-medium px-1.5 py-0.5 rounded-full shrink-0"
+                                      style={{
+                                        backgroundColor: tl.label.color + "18",
+                                        color: tl.label.color,
+                                      }}
+                                    >
+                                      {tl.label.name}
+                                    </span>
+                                  ))}
+                                  {tx.labels.length > 2 && (
+                                    <span className="text-[10px] text-warm-300 shrink-0">
+                                      +{tx.labels.length - 2}
+                                    </span>
+                                  )}
+                                </>
+                              )}
+                            </div>
                           </div>
                           <div className="text-right shrink-0">
                             <p


### PR DESCRIPTION
## Summary
- Display label chips next to category name on dashboard recent transactions widget
- Capped at 2 labels (with "+N" overflow) to fit the narrower widget layout vs 3 on the full transactions page
- Data was already being fetched with labels included (from PR #27), this just adds the UI rendering

## Test plan
- [ ] Verify label chips appear on dashboard recent transactions
- [ ] Confirm max 2 labels shown with "+N" overflow for transactions with 3+ labels
- [ ] Transactions without labels render as before (no visual change)
- [ ] Check mobile layout doesn't overflow