### PR TITLE
fix(ui): add icons to Itemized and Bill badges

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -14,6 +14,7 @@ import {
   EyeOff,
   ScanLine,
   CalendarClock,
+  Receipt,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
@@ -433,12 +434,14 @@ export default function DashboardPage() {
                                 {tx.description}
                               </p>
                               {tx.receiptGroupId && (
-                                <span className="shrink-0 bg-amber-light/60 text-amber-dark text-[10px] font-medium px-1.5 py-0.5 rounded">
+                                <span className="shrink-0 inline-flex items-center gap-0.5 bg-amber-light/60 text-amber-dark text-[10px] font-medium px-1.5 py-0.5 rounded">
+                                  <Receipt className="w-2.5 h-2.5" />
                                   Itemized
                                 </span>
                               )}
                               {tx.billId && (
-                                <span className="shrink-0 bg-income-light text-income text-[10px] font-medium px-1.5 py-0.5 rounded">
+                                <span className="shrink-0 inline-flex items-center gap-0.5 bg-income-light text-income text-[10px] font-medium px-1.5 py-0.5 rounded">
+                                  <CalendarClock className="w-2.5 h-2.5" />
                                   Bill
                                 </span>
                               )}

--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -12,6 +12,8 @@ import {
   X,
   Loader2,
   ScanLine,
+  Receipt,
+  CalendarClock,
 } from "lucide-react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
@@ -597,12 +599,14 @@ export default function TransactionsPage() {
                               {tx.description}
                             </p>
                             {tx.receiptGroupId && (
-                              <span className="shrink-0 bg-amber-light/60 text-amber-dark text-[10px] font-medium px-1.5 py-0.5 rounded">
+                              <span className="shrink-0 inline-flex items-center gap-0.5 bg-amber-light/60 text-amber-dark text-[10px] font-medium px-1.5 py-0.5 rounded">
+                                <Receipt className="w-2.5 h-2.5" />
                                 Itemized
                               </span>
                             )}
                             {tx.billId && (
-                              <span className="shrink-0 bg-income-light text-income text-[10px] font-medium px-1.5 py-0.5 rounded">
+                              <span className="shrink-0 inline-flex items-center gap-0.5 bg-income-light text-income text-[10px] font-medium px-1.5 py-0.5 rounded">
+                                <CalendarClock className="w-2.5 h-2.5" />
                                 Bill
                               </span>
                             )}


### PR DESCRIPTION
## Summary
- Add `Receipt` icon to "Itemized" badge and `CalendarClock` icon to "Bill" badge
- Applied to both the transactions page and dashboard recent transactions widget
- Visually distinguishes system badges (`rounded` + icon) from user-created label chips (`rounded-full`, no icon)

## Test plan
- [ ] Verify "Itemized" badge shows Receipt icon on transactions page
- [ ] Verify "Bill" badge shows CalendarClock icon on transactions page
- [ ] Same icons appear on dashboard recent transactions
- [ ] Labels still render as plain colored pills without icons
- [ ] No layout overflow on mobile