### PR TITLE
fix(labels): skip schedule auto-labeling when editing transactions

### DIFF
--- a/src/app/api/transactions/[id]/route.ts
+++ b/src/app/api/transactions/[id]/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getAuthUserId } from "@/lib/session";
 import { transactionSchema } from "@/lib/validations";
-import { getScheduleContext, matchScheduledLabel } from "@/lib/schedule-server";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -53,20 +52,14 @@ export async function PUT(request: Request, { params }: RouteParams) {
     // Server-side label reconciliation when labelIds not provided (cold-cache edits, hidden-label flows).
     // Always runs to enforce type compatibility, even for users without schedules.
     if (!hasLabelIds) {
-      const [ctx, existingLabels] = await Promise.all([
-        getScheduleContext(userId),
-        prisma.transactionLabel.findMany({
-          where: { transactionId: id },
-          include: { label: { select: { applicableTo: true } } },
-        }),
-      ]);
+      const existingLabels = await prisma.transactionLabel.findMany({
+        where: { transactionId: id },
+        include: { label: { select: { applicableTo: true } } },
+      });
 
-      // Preserve all existing labels, only dropping those incompatible with
-      // the (possibly changed) transaction type. We do NOT drop or re-add
-      // scheduled labels here — the client-side auto-label effect handles
-      // schedule changes during the editing session and sends explicit labelIds.
-      // When labelIds is omitted (cold-cache / hidden-label), preserving as-is
-      // respects prior user overrides (manual re-adds and quick-removes).
+      // Preserve existing labels, only dropping those incompatible with the
+      // (possibly changed) transaction type. We never re-apply scheduled labels
+      // on edit — preserving as-is respects prior user overrides.
       for (const el of existingLabels) {
         if (el.label.applicableTo !== "BOTH" && el.label.applicableTo !== validated.type) continue;
         verifiedLabelIds.push(el.labelId);

--- a/src/components/transactions/transaction-form.tsx
+++ b/src/components/transactions/transaction-form.tsx
@@ -107,8 +107,12 @@ export function TransactionForm({ transaction, initialData, dateWarning, hideLab
   const watchedDate = watch("date");
   const watchedLabelIds = watch("labelIds") ?? [];
 
-  // Auto-label scheduling
-  const { scheduledLabelId } = useScheduledLabel(watchedDate, selectedType);
+  // Auto-label scheduling — only for new transactions; edits preserve user's label choices
+  const isEditing = !!transaction;
+  const { scheduledLabelId } = useScheduledLabel(
+    isEditing ? undefined : watchedDate,
+    selectedType,
+  );
   const userRemovedAutoLabels = useRef<Set<string>>(new Set());
   const autoAppliedLabels = useRef<Set<string>>(new Set());
   const prevScheduledLabelId = useRef<string | null>(null);
@@ -167,22 +171,6 @@ export function TransactionForm({ transaction, initialData, dateWarning, hideLab
 
     // Read current label state imperatively to avoid stale closure issues
     const currentIds = getValues("labelIds") ?? [];
-
-    // On first computation for edits: seed tracking refs from the transaction's
-    // existing labels so the auto-label logic behaves correctly.
-    // We never seed autoAppliedLabels on edit — we can't distinguish "auto-applied
-    // earlier" from "user manually kept/re-added". Treating existing labels as
-    // user-owned means they won't be removed when the date moves outside the window.
-    if (prev === null && transaction && scheduledLabelId) {
-      const existingLabelIds = transaction.labels?.map((tl) => tl.labelId) ?? [];
-      if (!existingLabelIds.includes(scheduledLabelId)) {
-        // Schedule matches but label is absent (e.g. quick-removed from list
-        // view). Seed userRemovedAutoLabels so the effect doesn't re-add it.
-        userRemovedAutoLabels.current.add(scheduledLabelId);
-      }
-      // If the label IS present, leave it as user-owned (not in autoAppliedLabels).
-      // The user can still manually remove it via the picker if desired.
-    }
 
     // When the scheduled label changes, reset removal tracking for the new label
     if (scheduledLabelId !== prev && scheduledLabelId) {


### PR DESCRIPTION
Closes #35

## Summary

- Skip `useScheduledLabel` hook in edit mode by passing `undefined` date when `transaction` prop is present — schedule matching only runs for new transactions
- Remove dead edit-seeding logic (`userRemovedAutoLabels` seed block) that's no longer reachable
- Clean up unused `getScheduleContext`/`matchScheduledLabel` imports from PUT route
- Simplify server-side `!hasLabelIds` branch to only preserve existing labels without schedule context

## Test plan

- [ ] Create a new transaction on a scheduled day/time → scheduled label auto-applies
- [ ] Edit that transaction (e.g. change amount) → scheduled label is NOT re-applied
- [ ] Remove a scheduled label from a transaction, then edit it → removed label stays removed
- [ ] Change transaction type on edit → incompatible labels are still correctly dropped
- [ ] Create transaction with label picker hidden → server-side auto-label still works