### PR TITLE
fix(dashboard): snooze dropdown clipped by overflow-hidden container

### DIFF
--- a/src/components/dashboard/upcoming-bill-row.tsx
+++ b/src/components/dashboard/upcoming-bill-row.tsx
@@ -166,10 +166,10 @@ export function UpcomingBillRow({
         {isExpanded && (
           <motion.div
             initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: "auto" }}
-            exit={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto", transitionEnd: { overflow: "visible" } }}
+            exit={{ opacity: 0, height: 0, overflow: "hidden" }}
             transition={{ duration: 0.15 }}
-            className="overflow-hidden"
+            style={{ overflow: "hidden" }}
           >
             <div className="flex items-center gap-2 pt-2 pl-10">
               {/* Pay */}


### PR DESCRIPTION
Closes #37

## Summary

- The snooze dropdown on upcoming bills was invisible because the parent `motion.div` had `overflow-hidden` for the expand/collapse animation, clipping the absolutely-positioned dropdown
- Use framer-motion's `transitionEnd` to switch to `overflow: visible` after the enter animation completes, and revert to `overflow: hidden` on exit

## Test plan

- [ ] Expand an upcoming bill row → click Snooze → dropdown menu appears with 1 day / 3 days / 1 week options
- [ ] Select a snooze option → bill is snoozed, toast shows
- [ ] Collapse and re-expand the row → expand/collapse animation still looks clean (no content flash)
- [ ] Pay and Skip buttons still work as expected