### PR TITLE
fix(labels): add label support and opt-out to batch transaction endpoint

### DIFF
--- a/src/app/api/transactions/batch/route.ts
+++ b/src/app/api/transactions/batch/route.ts
@@ -42,8 +42,9 @@ export async function POST(request: Request) {
       ownedLabelMap = new Map(ownedLabels.map((l) => [l.id, l.applicableTo]));
     }
 
-    // Fetch schedule context for auto-tagging (short-circuits when no schedules exist)
-    const ctx = await getScheduleContext(userId);
+    // Fetch schedule context only when at least one item needs auto-tagging
+    const needsAutoLabel = transactions.some((t) => t.labelIds === undefined);
+    const ctx = needsAutoLabel ? await getScheduleContext(userId) : null;
 
     const created = await prisma.$transaction(
       transactions.map((t) => {

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -100,11 +100,12 @@ export async function POST(request: Request) {
     // Validate label ownership and type compatibility before writing
     const verifiedLabelIds: string[] = [];
     if (validated.labelIds && validated.labelIds.length > 0) {
+      const uniqueLabelIds = [...new Set(validated.labelIds)];
       const ownedLabels = await prisma.label.findMany({
-        where: { id: { in: validated.labelIds }, userId },
+        where: { id: { in: uniqueLabelIds }, userId },
         select: { id: true, applicableTo: true },
       });
-      if (ownedLabels.length !== validated.labelIds.length) {
+      if (ownedLabels.length !== uniqueLabelIds.length) {
         return NextResponse.json(
           { error: "One or more labels are invalid or do not belong to you" },
           { status: 400 }


### PR DESCRIPTION
## Summary
Closes #43

- Batch transaction endpoint (`POST /api/transactions/batch`) now supports per-item `labelIds` with the same 3-state semantics as single create:
  - `undefined` → server auto-applies scheduled labels (receipt scanning flow unchanged)
  - `[]` → user explicitly opted out, no labels applied
  - `['id1', ...]` → validated for ownership + `applicableTo` type compatibility
- All explicit label IDs are validated in a single batched ownership query before processing
- Uses `createMany` to support multiple labels per batch item

## Test plan
- [ ] Create transactions via receipt scan (no `labelIds` sent) → verify scheduled labels still auto-apply
- [ ] Call batch endpoint with `labelIds: []` on an item → verify no labels are applied
- [ ] Call batch endpoint with explicit `labelIds` → verify ownership check rejects invalid/foreign labels
- [ ] Call batch endpoint with a label whose `applicableTo` doesn't match transaction type → verify it's filtered out
- [ ] Verify existing single create and edit flows are unaffected