### PR TITLE
docs: align env var name with code (EMAIL_FROM)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ src/
 - `NEXTAUTH_SECRET` / `NEXTAUTH_URL` — NextAuth session config
 - `GEMINI_API_KEY` — Google Gemini AI for receipt scanning
 - `RESEND_API_KEY` — Email sending (verification + password reset)
-- `RESEND_FROM_EMAIL` — Sender address (defaults to `onboarding@resend.dev` in dev)
+- `EMAIL_FROM` — Sender address (optional; defaults to `Budget Tracker <noreply@resend.dev>` if unset). Use a verified Resend domain in production, e.g. `Budget Tracker <noreply@yourdomain.com>`.
 - `AUTH_URL` — Optional; used in preview/staging deployments
 - `CRON_SECRET` — Shared secret required by `/api/cron/bill-reminders`. Set in the production (Coolify) environment; a Coolify Scheduled Task reuses the same env var to call the endpoint daily (see **Cron Jobs** below).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -723,7 +723,7 @@ All notable development history for the Budget Tracker app.
 
 ### Environment Variables
 - `RESEND_API_KEY` — required for sending verification and reset emails
-- `RESEND_FROM_EMAIL` — sender address (defaults to `onboarding@resend.dev` for development)
+- `EMAIL_FROM` — sender address (optional; defaults to `Budget Tracker <noreply@resend.dev>` for development)
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix latent footgun where `AGENTS.md` and `CHANGELOG.md` referenced a non-existent `RESEND_FROM_EMAIL` env var
- `src/lib/email.ts:23` actually reads `process.env.EMAIL_FROM`, and `.env.example` already uses `EMAIL_FROM` — the docs were the outlier
- Also corrected the documented default value to match the code (`Budget Tracker <noreply@resend.dev>`, not `onboarding@resend.dev`)
- No code or runtime behavior changes — docs-only

## Why this matters

Anyone setting up the app from the docs would add `RESEND_FROM_EMAIL` to their env and silently fall back to the default sender, which on Resend's sandbox domain only delivers to the account owner. Discovered while debugging a bill-reminder email delivery issue.

## Test plan

- [ ] `AGENTS.md` env var table lists `EMAIL_FROM`
- [ ] `CHANGELOG.md` 2026-03-08 entry lists `EMAIL_FROM`
- [ ] `grep -r RESEND_FROM_EMAIL` returns no matches in the repo