### PR TITLE
feat(nav): swap Transactions and Analytics order

### DIFF
--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -50,8 +50,8 @@ const withLocalTime = (dateStr: string): string => {
 
 const NAV_ITEMS = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/analytics", label: "Analytics", icon: BarChart3 },
   { href: "/transactions", label: "Transactions", icon: ArrowLeftRight },
+  { href: "/analytics", label: "Analytics", icon: BarChart3 },
   { href: "/bills", label: "Bills", icon: CalendarClock },
   { href: "/categories", label: "Categories", icon: Tags },
   { href: "/labels", label: "Labels", icon: Tag },


### PR DESCRIPTION
## Summary
- Swap the order of **Transactions** and **Analytics** in `NAV_ITEMS` (used by both the desktop side nav and the mobile bottom nav).
- Transactions is accessed far more often than Analytics, so it now sits closer to Dashboard.

New order: Dashboard → Transactions → Analytics → Bills → Categories → Labels.

Closes #66

## Test plan
- [ ] Desktop sidebar shows Dashboard, Transactions, Analytics, Bills, Categories, Labels in that order
- [ ] Mobile bottom nav shows Dashboard, Transactions, Analytics, Bills, Categories (Labels still filtered)
- [ ] Active-state highlight still works when navigating to each route
- [ ] `pnpm lint` and `pnpm type-check` pass