### PR TITLE
ci: add GitHub Actions workflow (lint + type-check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type check
+        run: pnpm type-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Generate Next.js route types
+        run: pnpm exec next typegen
+
       - name: Type check
         run: pnpm type-check


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` that runs on push to `main` and PRs targeting `main`.
- Uses pnpm + Node 20 to match project standards (`engines.node: >=20.0.0`).
- Steps: checkout → setup pnpm → setup Node 20 (with pnpm cache) → `pnpm install --frozen-lockfile` → `pnpm lint` → `pnpm type-check`.
- Prisma client is generated automatically via the `postinstall` hook, so no explicit `prisma generate` step is needed.

Closes #68

## Out of scope (noted in issue)
- `pnpm build` — needs a Postgres service because `build` runs `prisma migrate deploy`.
- Test step — no `test` script / test suite exists yet.

## Test plan
- [ ] After merge, confirm the CI workflow appears on the Actions tab
- [ ] Open a dummy PR or push to verify `lint` and `type-check` steps both run and pass
- [ ] Confirm `postinstall` generates the Prisma client without errors in the runner logs
- [ ] Verify pnpm cache is populated on the second run