### PR TITLE
feat(scan): use photo capture date as fallback for unreadable receipt dates

### DIFF
--- a/src/app/api/receipts/breakdown/route.ts
+++ b/src/app/api/receipts/breakdown/route.ts
@@ -2,13 +2,8 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { gemini, GEMINI_MODEL } from "@/lib/gemini";
 import { getAuthUserId } from "@/lib/session";
-import { receiptBreakdownResultSchema, validDateString } from "@/lib/validations";
-
-/** Parse a YYYY-MM-DD string with calendar validation. Returns the input on success, fallback otherwise. */
-const parseLocalDate = (raw: FormDataEntryValue | null, fallback: string): string => {
-  if (typeof raw !== "string") return fallback;
-  return validDateString.safeParse(raw).success ? raw : fallback;
-};
+import { receiptBreakdownResultSchema } from "@/lib/validations";
+import { parseLocalDate, checkReceiptDate } from "@/lib/receipt-date";
 
 const ALLOWED_TYPES = new Set([
   "image/jpeg",
@@ -38,24 +33,6 @@ const MAX_FILE_SIZE = 4 * 1024 * 1024; // 4 MB
 /** Strip markdown code fences that Gemini sometimes wraps around JSON */
 const stripCodeFences = (text: string): string =>
   text.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "");
-
-/** Normalize receipt date and flag when the year differs from today.
- *  Uses photoFallback (the photo's capture date) when Gemini's date is unparseable
- *  or when the parsed year differs from today — preserving the warning flag for the UI. */
-const checkReceiptDate = (
-  dateStr: string,
-  todayStr: string,
-  photoFallback: string,
-): { date: string; dateWarning: boolean } => {
-  const dateOnly = dateStr.slice(0, 10); // normalize "2024-03-14T13:45" → "2024-03-14"
-  const parsed = new Date(dateOnly + "T00:00:00");
-  if (isNaN(parsed.getTime())) return { date: photoFallback, dateWarning: false };
-  const todayYear = new Date(todayStr + "T00:00:00").getFullYear();
-  if (parsed.getFullYear() !== todayYear) {
-    return { date: photoFallback, dateWarning: true };
-  }
-  return { date: dateOnly, dateWarning: false };
-};
 
 export async function POST(request: Request) {
   const userId = await getAuthUserId();

--- a/src/app/api/receipts/breakdown/route.ts
+++ b/src/app/api/receipts/breakdown/route.ts
@@ -2,7 +2,13 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { gemini, GEMINI_MODEL } from "@/lib/gemini";
 import { getAuthUserId } from "@/lib/session";
-import { receiptBreakdownResultSchema } from "@/lib/validations";
+import { receiptBreakdownResultSchema, validDateString } from "@/lib/validations";
+
+/** Parse a YYYY-MM-DD string with calendar validation. Returns the input on success, fallback otherwise. */
+const parseLocalDate = (raw: FormDataEntryValue | null, fallback: string): string => {
+  if (typeof raw !== "string") return fallback;
+  return validDateString.safeParse(raw).success ? raw : fallback;
+};
 
 const ALLOWED_TYPES = new Set([
   "image/jpeg",
@@ -34,15 +40,21 @@ const stripCodeFences = (text: string): string =>
   text.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "");
 
 /** Normalize receipt date and flag when the year differs from today.
- *  Extracts the date portion to handle both "YYYY-MM-DD" and full ISO timestamps.
- *  Never modifies the date — returns a warning flag instead so the UI can
- *  prompt the user to confirm or correct it. */
-const checkReceiptDate = (dateStr: string, fallback: string): { date: string; dateWarning: boolean } => {
+ *  Uses photoFallback (the photo's capture date) when Gemini's date is unparseable
+ *  or when the parsed year differs from today — preserving the warning flag for the UI. */
+const checkReceiptDate = (
+  dateStr: string,
+  todayStr: string,
+  photoFallback: string,
+): { date: string; dateWarning: boolean } => {
   const dateOnly = dateStr.slice(0, 10); // normalize "2024-03-14T13:45" → "2024-03-14"
   const parsed = new Date(dateOnly + "T00:00:00");
-  if (isNaN(parsed.getTime())) return { date: fallback, dateWarning: false };
-  const todayYear = new Date(fallback + "T00:00:00").getFullYear();
-  return { date: dateOnly, dateWarning: parsed.getFullYear() !== todayYear };
+  if (isNaN(parsed.getTime())) return { date: photoFallback, dateWarning: false };
+  const todayYear = new Date(todayStr + "T00:00:00").getFullYear();
+  if (parsed.getFullYear() !== todayYear) {
+    return { date: photoFallback, dateWarning: true };
+  }
+  return { date: dateOnly, dateWarning: false };
 };
 
 export async function POST(request: Request) {
@@ -129,8 +141,11 @@ export async function POST(request: Request) {
       .map((c) => `- "${c.name}" (id: "${c.id}")`)
       .join("\n");
 
-    // Date-only fallback — time is appended on the client using the user's local clock
-    const todayStr = new Date().toISOString().slice(0, 10);
+    // Date-only fallback — prefer client's local date to avoid UTC offset issues.
+    const serverToday = new Date().toISOString().slice(0, 10);
+    const todayStr = parseLocalDate(formData.get("localDate"), serverToday);
+    // Photo capture date from the original (uncompressed) File on the client.
+    const photoDateStr = parseLocalDate(formData.get("photoDate"), todayStr);
 
     const arrayBuffer = await file.arrayBuffer();
     const base64 = Buffer.from(arrayBuffer).toString("base64");
@@ -159,7 +174,7 @@ CATEGORY RULES:
 
 RESPONSE FORMAT — return ONLY valid JSON, no markdown or explanation:
 {
-  "date": "<YYYY-MM-DD — the TRANSACTION/purchase date, usually near the top of the receipt next to the time. IGNORE any 'Date of Issuance', PTU accreditation, permit, or BIR registration dates. Use ${todayStr} if unreadable>",
+  "date": "<YYYY-MM-DD — the TRANSACTION/purchase date, usually near the top of the receipt next to the time. IGNORE any 'Date of Issuance', PTU accreditation, permit, or BIR registration dates. Use ${photoDateStr} if unreadable>",
   "items": [
     {
       "amount": <sum of items in this category>,
@@ -241,7 +256,7 @@ RULES:
     }
 
     // Normalize date and flag suspicious year for the UI
-    const { date: normalizedDate, dateWarning } = checkReceiptDate(result.data.date, todayStr);
+    const { date: normalizedDate, dateWarning } = checkReceiptDate(result.data.date, todayStr, photoDateStr);
     result.data.date = normalizedDate;
 
     // Verify each categoryId exists, fall back to "Other" if not

--- a/src/app/api/receipts/scan/route.ts
+++ b/src/app/api/receipts/scan/route.ts
@@ -2,13 +2,8 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { gemini, GEMINI_MODEL } from "@/lib/gemini";
 import { getAuthUserId } from "@/lib/session";
-import { receiptScanResultSchema, validDateString } from "@/lib/validations";
-
-/** Parse a YYYY-MM-DD string with calendar validation. Returns the input on success, fallback otherwise. */
-const parseLocalDate = (raw: FormDataEntryValue | null, fallback: string): string => {
-  if (typeof raw !== "string") return fallback;
-  return validDateString.safeParse(raw).success ? raw : fallback;
-};
+import { receiptScanResultSchema } from "@/lib/validations";
+import { parseLocalDate, checkReceiptDate } from "@/lib/receipt-date";
 
 const ALLOWED_TYPES = new Set([
   "image/jpeg",
@@ -40,25 +35,6 @@ const MAX_FILE_SIZE = 4 * 1024 * 1024; // 4 MB
 /** Strip markdown code fences that Gemini sometimes wraps around JSON */
 const stripCodeFences = (text: string): string =>
   text.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "");
-
-/** Normalize receipt date and flag when the year differs from today.
- *  Extracts the date portion to handle both "YYYY-MM-DD" and full ISO timestamps.
- *  Uses photoFallback (the photo's capture date) when Gemini's date is unparseable
- *  or when the parsed year differs from today — preserving the warning flag for the UI. */
-const checkReceiptDate = (
-  dateStr: string,
-  todayStr: string,
-  photoFallback: string,
-): { date: string; dateWarning: boolean } => {
-  const dateOnly = dateStr.slice(0, 10); // normalize "2024-03-14T13:45" → "2024-03-14"
-  const parsed = new Date(dateOnly + "T00:00:00");
-  if (isNaN(parsed.getTime())) return { date: photoFallback, dateWarning: false };
-  const todayYear = new Date(todayStr + "T00:00:00").getFullYear();
-  if (parsed.getFullYear() !== todayYear) {
-    return { date: photoFallback, dateWarning: true };
-  }
-  return { date: dateOnly, dateWarning: false };
-};
 
 export async function POST(request: Request) {
   const userId = await getAuthUserId();

--- a/src/app/api/receipts/scan/route.ts
+++ b/src/app/api/receipts/scan/route.ts
@@ -37,14 +37,21 @@ const stripCodeFences = (text: string): string =>
 
 /** Normalize receipt date and flag when the year differs from today.
  *  Extracts the date portion to handle both "YYYY-MM-DD" and full ISO timestamps.
- *  Never modifies the date — returns a warning flag instead so the UI can
- *  prompt the user to confirm or correct it. */
-const checkReceiptDate = (dateStr: string, fallback: string): { date: string; dateWarning: boolean } => {
+ *  Uses photoFallback (the photo's capture date) when Gemini's date is unparseable
+ *  or when the parsed year differs from today — preserving the warning flag for the UI. */
+const checkReceiptDate = (
+  dateStr: string,
+  todayStr: string,
+  photoFallback: string,
+): { date: string; dateWarning: boolean } => {
   const dateOnly = dateStr.slice(0, 10); // normalize "2024-03-14T13:45" → "2024-03-14"
   const parsed = new Date(dateOnly + "T00:00:00");
-  if (isNaN(parsed.getTime())) return { date: fallback, dateWarning: false };
-  const todayYear = new Date(fallback + "T00:00:00").getFullYear();
-  return { date: dateOnly, dateWarning: parsed.getFullYear() !== todayYear };
+  if (isNaN(parsed.getTime())) return { date: photoFallback, dateWarning: false };
+  const todayYear = new Date(todayStr + "T00:00:00").getFullYear();
+  if (parsed.getFullYear() !== todayYear) {
+    return { date: photoFallback, dateWarning: true };
+  }
+  return { date: dateOnly, dateWarning: false };
 };
 
 export async function POST(request: Request) {
@@ -144,6 +151,15 @@ export async function POST(request: Request) {
       typeof localDate === "string" && /^\d{4}-\d{2}-\d{2}$/.test(localDate)
         ? localDate
         : new Date().toISOString().slice(0, 10);
+
+    // Photo capture date from the original (uncompressed) File on the client.
+    // Used as the fallback when Gemini's date is unreadable or has a wrong year.
+    // Falls back to todayStr when missing/invalid so behavior is unchanged for older clients.
+    const photoDate = formData.get("photoDate");
+    const photoDateStr =
+      typeof photoDate === "string" && /^\d{4}-\d{2}-\d{2}$/.test(photoDate)
+        ? photoDate
+        : todayStr;
 
     // Convert file to base64
     const arrayBuffer = await file.arrayBuffer();
@@ -245,7 +261,7 @@ or when multiCategory is true:
     }
 
     // Normalize date and flag suspicious year for the UI
-    const { date: normalizedDate, dateWarning } = checkReceiptDate(result.data.date, todayStr);
+    const { date: normalizedDate, dateWarning } = checkReceiptDate(result.data.date, todayStr, photoDateStr);
     result.data.date = normalizedDate;
 
     // Verify the categoryId actually exists in user's categories

--- a/src/app/api/receipts/scan/route.ts
+++ b/src/app/api/receipts/scan/route.ts
@@ -2,7 +2,13 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { gemini, GEMINI_MODEL } from "@/lib/gemini";
 import { getAuthUserId } from "@/lib/session";
-import { receiptScanResultSchema } from "@/lib/validations";
+import { receiptScanResultSchema, validDateString } from "@/lib/validations";
+
+/** Parse a YYYY-MM-DD string with calendar validation. Returns the input on success, fallback otherwise. */
+const parseLocalDate = (raw: FormDataEntryValue | null, fallback: string): string => {
+  if (typeof raw !== "string") return fallback;
+  return validDateString.safeParse(raw).success ? raw : fallback;
+};
 
 const ALLOWED_TYPES = new Set([
   "image/jpeg",
@@ -145,21 +151,15 @@ export async function POST(request: Request) {
       .map((c) => `- "${c.name}" (id: "${c.id}")`)
       .join("\n");
 
-    // Date-only fallback — prefer client's local date to avoid UTC offset issues
-    const localDate = formData.get("localDate");
-    const todayStr =
-      typeof localDate === "string" && /^\d{4}-\d{2}-\d{2}$/.test(localDate)
-        ? localDate
-        : new Date().toISOString().slice(0, 10);
+    // Date-only fallback — prefer client's local date to avoid UTC offset issues.
+    // Calendar-valid (rejects e.g. "2024-13-40") to keep server output trustworthy.
+    const serverToday = new Date().toISOString().slice(0, 10);
+    const todayStr = parseLocalDate(formData.get("localDate"), serverToday);
 
     // Photo capture date from the original (uncompressed) File on the client.
     // Used as the fallback when Gemini's date is unreadable or has a wrong year.
     // Falls back to todayStr when missing/invalid so behavior is unchanged for older clients.
-    const photoDate = formData.get("photoDate");
-    const photoDateStr =
-      typeof photoDate === "string" && /^\d{4}-\d{2}-\d{2}$/.test(photoDate)
-        ? photoDate
-        : todayStr;
+    const photoDateStr = parseLocalDate(formData.get("photoDate"), todayStr);
 
     // Convert file to base64
     const arrayBuffer = await file.arrayBuffer();
@@ -172,7 +172,7 @@ If the image is NOT a receipt (e.g. a random photo, screenshot, or document), re
 Return a JSON object with these fields:
 - "amount": the grand total / total due including tax, tips, and service charges (number). Use the largest final amount on the receipt.
 - "categoryId": pick the best category ID using the rules below.
-- "date": the TRANSACTION date (the date of purchase, usually near the top of the receipt next to the time). Use "YYYY-MM-DD" format (date only, no time). IMPORTANT: Ignore any "Date of Issuance", PTU accreditation dates, permit dates, or BIR registration dates — these are regulatory dates, NOT the purchase date. If the transaction date is unreadable, use "${todayStr}".
+- "date": the TRANSACTION date (the date of purchase, usually near the top of the receipt next to the time). Use "YYYY-MM-DD" format (date only, no time). IMPORTANT: Ignore any "Date of Issuance", PTU accreditation dates, permit dates, or BIR registration dates — these are regulatory dates, NOT the purchase date. If the transaction date is unreadable, use "${photoDateStr}".
 - "description": merchant name + short summary of purchase (max 100 chars).
 - "multiCategory": true if the receipt contains items that span 2 or more DIFFERENT categories from the list below, false if all items belong to a single category. For example, a grocery receipt with food AND cleaning supplies = true, a restaurant bill with only food = false, a single ride receipt = false.
 - "breakdown": ONLY include this field when "multiCategory" is true. Read every line item on the receipt and group them by category. Each entry has: "amount" (sum for that category), "categoryId", "description" (store name + category + 1-2 sample items, max 80 chars), and "lineItems" (array of {"name": "<item name>", "amount": <price>}). The sum of all breakdown amounts should approximately equal the receipt total. Distribute tax/service proportionally or into the largest group. Do NOT include breakdown when multiCategory is false.

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -374,6 +374,14 @@ export function AppShell({ children }: AppShellProps) {
     try {
       const formData = new FormData();
       formData.append("receipt", item.imageFile);
+      formData.append("localDate", toLocalDateString(new Date()));
+      // Photo date sourced from the compressed file's preserved lastModified
+      formData.append(
+        "photoDate",
+        toLocalDateString(
+          item.imageFile.lastModified ? new Date(item.imageFile.lastModified) : new Date()
+        )
+      );
 
       const res = await fetch("/api/receipts/breakdown", {
         method: "POST",

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -18,7 +18,7 @@ import {
   Shield,
   AlertTriangle,
 } from "lucide-react";
-import { cn, compressImage, formatDateInput } from "@/lib/utils";
+import { cn, compressImage, formatDateInput, toLocalDateString } from "@/lib/utils";
 import { motion } from "framer-motion";
 import { useUser } from "@/components/user-provider";
 import { ScanProvider } from "@/components/scan-provider";
@@ -95,11 +95,15 @@ export function AppShell({ children }: AppShellProps) {
     setScanError(null);
 
     try {
+      // Capture photoDate BEFORE compression — canvas re-encoding loses File metadata
+      const photoDate = toLocalDateString(
+        file.lastModified ? new Date(file.lastModified) : new Date()
+      );
       const compressed = await compressImage(file);
       const formData = new FormData();
       formData.append("receipt", compressed);
-      const now = new Date();
-      formData.append("localDate", `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`);
+      formData.append("localDate", toLocalDateString(new Date()));
+      formData.append("photoDate", photoDate);
 
       const res = await fetch("/api/receipts/scan", {
         method: "POST",
@@ -170,6 +174,11 @@ export function AppShell({ children }: AppShellProps) {
       setMultiScanItems(initialItems);
       setShowMultiScanReview(true);
 
+      // Capture photoDate per file BEFORE compression — canvas re-encoding loses File metadata
+      const photoDates = files.map((f) =>
+        toLocalDateString(f.lastModified ? new Date(f.lastModified) : new Date())
+      );
+
       // Compress all files in parallel (client-side only, no API cost)
       const compressed = await Promise.all(
         files.map((f) => compressImage(f).catch(() => f))
@@ -188,8 +197,8 @@ export function AppShell({ children }: AppShellProps) {
           try {
             const formData = new FormData();
             formData.append("receipt", file);
-            const n = new Date();
-            formData.append("localDate", `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(n.getDate()).padStart(2, "0")}`);
+            formData.append("localDate", toLocalDateString(new Date()));
+            formData.append("photoDate", photoDates[i]);
 
             const res = await fetch("/api/receipts/scan", {
               method: "POST",

--- a/src/lib/receipt-date.ts
+++ b/src/lib/receipt-date.ts
@@ -7,8 +7,10 @@ export const parseLocalDate = (raw: FormDataEntryValue | null, fallback: string)
 };
 
 /** Normalize a receipt date returned by Gemini and flag when the year differs from today.
- *  Uses photoFallback (the photo's capture date) when Gemini's date is unparseable
- *  or when the parsed year differs from today — preserving the warning flag for the UI. */
+ *  Uses photoFallback (the photo's capture date) only when parsing fails — preserving
+ *  legitimate cross-year OCR dates (e.g. a 2025 receipt scanned in early 2026).
+ *  When the year is suspicious, the OCR date is kept and dateWarning is raised so the UI
+ *  can prompt the user to confirm or correct it. */
 export const checkReceiptDate = (
   dateStr: string,
   todayStr: string,
@@ -18,8 +20,5 @@ export const checkReceiptDate = (
   const parsed = new Date(dateOnly + "T00:00:00");
   if (isNaN(parsed.getTime())) return { date: photoFallback, dateWarning: false };
   const todayYear = new Date(todayStr + "T00:00:00").getFullYear();
-  if (parsed.getFullYear() !== todayYear) {
-    return { date: photoFallback, dateWarning: true };
-  }
-  return { date: dateOnly, dateWarning: false };
+  return { date: dateOnly, dateWarning: parsed.getFullYear() !== todayYear };
 };

--- a/src/lib/receipt-date.ts
+++ b/src/lib/receipt-date.ts
@@ -1,0 +1,25 @@
+import { validDateString } from "@/lib/validations";
+
+/** Parse a YYYY-MM-DD string with calendar validation. Returns the input on success, fallback otherwise. */
+export const parseLocalDate = (raw: FormDataEntryValue | null, fallback: string): string => {
+  if (typeof raw !== "string") return fallback;
+  return validDateString.safeParse(raw).success ? raw : fallback;
+};
+
+/** Normalize a receipt date returned by Gemini and flag when the year differs from today.
+ *  Uses photoFallback (the photo's capture date) when Gemini's date is unparseable
+ *  or when the parsed year differs from today — preserving the warning flag for the UI. */
+export const checkReceiptDate = (
+  dateStr: string,
+  todayStr: string,
+  photoFallback: string,
+): { date: string; dateWarning: boolean } => {
+  const dateOnly = dateStr.slice(0, 10); // normalize "2024-03-14T13:45" → "2024-03-14"
+  const parsed = new Date(dateOnly + "T00:00:00");
+  if (isNaN(parsed.getTime())) return { date: photoFallback, dateWarning: false };
+  const todayYear = new Date(todayStr + "T00:00:00").getFullYear();
+  if (parsed.getFullYear() !== todayYear) {
+    return { date: photoFallback, dateWarning: true };
+  }
+  return { date: dateOnly, dateWarning: false };
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,6 +36,14 @@ export const formatDateInput = (date: Date | string): string => {
   return `${year}-${month}-${day}T${hours}:${minutes}`;
 };
 
+/** Format a Date as local YYYY-MM-DD (no UTC conversion) */
+export const toLocalDateString = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
 /** Get month name from date */
 export const getMonthName = (date: Date | string): string =>
   new Intl.DateTimeFormat("en-US", { month: "long" }).format(new Date(date));

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -108,6 +108,7 @@ export const compressImage = (file: File): Promise<File> => {
           }
           resolve(new File([blob], file.name.replace(/\.\w+$/, ".jpg"), {
             type: "image/jpeg",
+            lastModified: file.lastModified, // preserve original capture time for downstream date inference
           }));
         },
         "image/jpeg",

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -156,7 +156,7 @@ export const resetPasswordSchema = z.object({
   path: ["confirmPassword"],
 });
 
-const validDateString = z
+export const validDateString = z
   .string()
   .regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date format (YYYY-MM-DD)")
   .refine((s) => {


### PR DESCRIPTION
Closes #70

## Summary
- Send `photoDate` (YYYY-MM-DD from the original `File.lastModified`) alongside `localDate` when posting to `/api/receipts/scan` for both single-scan and multi-scan flows.
- Server uses `photoDate` (instead of today) as the fallback when Gemini's date is unparseable, and as the substituted date when Gemini's parsed year differs from today (`dateWarning` still fires so the UI keeps prompting the user).
- Add a small `toLocalDateString` helper in `src/lib/utils.ts` to dedupe local YYYY-MM-DD formatting and reuse it on the client.

## Why
Today, when Gemini can't read the receipt date — or returns a wrong year from an OCR misread — the server silently falls back to today. We already have a better signal on the client: the photo's capture timestamp. Using it preserves more accurate dates for users who scan a receipt right after the purchase, without overriding correctly-parsed receipt dates.

## Behavior matrix
| Gemini result                       | Before               | After                          |
|------------------------------------|----------------------|--------------------------------|
| Parsed, current year                | Gemini's date         | Gemini's date (unchanged)      |
| Parsed, year ≠ today                | Gemini's date + ⚠     | `photoDate` + ⚠ (UI warning preserved) |
| Unparseable                         | today                 | `photoDate`                    |
| `photoDate` missing/invalid         | n/a                   | falls back to today (legacy behavior) |

## Regression guardrails
- `localDate` remains the source for `todayStr` and the year comparison.
- `photoDate` is **optional** server-side; older clients (or odd payloads) still get the previous behavior.
- `receiptScanResultSchema`, the `/api/receipts/breakdown` route, and `multi-scan-review.tsx` are untouched.
- `lint` and `type-check` pass.

## Implementation notes
- `photoDate` is captured from the **original** `File` *before* `compressImage()` runs — canvas re-encoding loses File metadata.
- Used `file.lastModified` (no new dependency) rather than EXIF. For phone-camera captures that's the capture time. EXIF (`exifr`) would be marginally better for old gallery picks; can be added later if needed.

## Test plan
- [ ] Scan a clean current-year receipt → date matches receipt (unchanged behavior).
- [ ] Scan a blurry receipt where Gemini can't read the date → transaction date = photo capture date (was: today).
- [ ] Reproduce a wrong-year scan → ⚠ warning shows; date = photo capture date.
- [ ] Multi-scan with several files → each item gets its own photo date.
- [ ] Test on mobile (PWA) using `<input capture>` to confirm `lastModified` matches capture time.
- [ ] Run `pnpm lint` and `pnpm type-check` (passing locally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Receipt scanning now falls back to the photo's date when the scanned date is unreadable or the year looks suspicious, improving date accuracy.
  * Single- and multi-receipt uploads now include localDate and per-photo photoDate so each receipt preserves its captured date.
  * Date parsing/validation tightened to enforce local YYYY-MM-DD formatting and produce more consistent UI date warnings.

* **New Features**
  * Added shared utilities for local date formatting and robust receipt date normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->