### PR TITLE
feat(scan): use photo capture time when photo-date fallback fires

### DIFF
--- a/src/app/api/receipts/breakdown/route.ts
+++ b/src/app/api/receipts/breakdown/route.ts
@@ -152,6 +152,7 @@ CATEGORY RULES:
 RESPONSE FORMAT — return ONLY valid JSON, no markdown or explanation:
 {
   "date": "<YYYY-MM-DD — the TRANSACTION/purchase date, usually near the top of the receipt next to the time. IGNORE any 'Date of Issuance', PTU accreditation, permit, or BIR registration dates. Use ${photoDateStr} if unreadable>",
+  "dateSource": "<\"OCR\" if you read the date from the receipt, or \"PHOTO_FALLBACK\" if you used the fallback ${photoDateStr} because the date was unreadable. Always include this field.>",
   "items": [
     {
       "amount": <sum of items in this category>,
@@ -233,7 +234,9 @@ RULES:
     }
 
     // Normalize date and flag suspicious year for the UI
-    const { date: normalizedDate, dateWarning, usedPhotoFallback } = checkReceiptDate(result.data.date, todayStr, photoDateStr);
+    const { date: normalizedDate, dateWarning, usedPhotoFallback: parseFailed } = checkReceiptDate(result.data.date, todayStr, photoDateStr);
+    // Trust Gemini's explicit signal first; fall back to parse-failure detection.
+    const usedPhotoFallback = result.data.dateSource === "PHOTO_FALLBACK" || parseFailed;
     result.data.date = normalizedDate;
 
     // Verify each categoryId exists, fall back to "Other" if not

--- a/src/app/api/receipts/breakdown/route.ts
+++ b/src/app/api/receipts/breakdown/route.ts
@@ -233,7 +233,7 @@ RULES:
     }
 
     // Normalize date and flag suspicious year for the UI
-    const { date: normalizedDate, dateWarning } = checkReceiptDate(result.data.date, todayStr, photoDateStr);
+    const { date: normalizedDate, dateWarning, usedPhotoFallback } = checkReceiptDate(result.data.date, todayStr, photoDateStr);
     result.data.date = normalizedDate;
 
     // Verify each categoryId exists, fall back to "Other" if not
@@ -250,7 +250,7 @@ RULES:
     // Log 1 scan credit for the breakdown (fire-and-forget)
     prisma.scanLog.create({ data: { userId } }).catch(() => {});
 
-    return NextResponse.json({ ...result.data, dateWarning });
+    return NextResponse.json({ ...result.data, dateWarning, usedPhotoFallback });
   } catch {
     return NextResponse.json(
       { error: "Failed to break down receipt. Please try again." },

--- a/src/app/api/receipts/scan/route.ts
+++ b/src/app/api/receipts/scan/route.ts
@@ -237,7 +237,7 @@ or when multiCategory is true:
     }
 
     // Normalize date and flag suspicious year for the UI
-    const { date: normalizedDate, dateWarning } = checkReceiptDate(result.data.date, todayStr, photoDateStr);
+    const { date: normalizedDate, dateWarning, usedPhotoFallback } = checkReceiptDate(result.data.date, todayStr, photoDateStr);
     result.data.date = normalizedDate;
 
     // Verify the categoryId actually exists in user's categories
@@ -261,7 +261,7 @@ or when multiCategory is true:
     // Log successful scan for monthly limit tracking (fire-and-forget)
     prisma.scanLog.create({ data: { userId } }).catch(() => {});
 
-    return NextResponse.json({ ...result.data, dateWarning });
+    return NextResponse.json({ ...result.data, dateWarning, usedPhotoFallback });
   } catch {
     return NextResponse.json(
       { error: "Failed to scan receipt. Please try again." },

--- a/src/app/api/receipts/scan/route.ts
+++ b/src/app/api/receipts/scan/route.ts
@@ -149,6 +149,7 @@ Return a JSON object with these fields:
 - "amount": the grand total / total due including tax, tips, and service charges (number). Use the largest final amount on the receipt.
 - "categoryId": pick the best category ID using the rules below.
 - "date": the TRANSACTION date (the date of purchase, usually near the top of the receipt next to the time). Use "YYYY-MM-DD" format (date only, no time). IMPORTANT: Ignore any "Date of Issuance", PTU accreditation dates, permit dates, or BIR registration dates — these are regulatory dates, NOT the purchase date. If the transaction date is unreadable, use "${photoDateStr}".
+- "dateSource": "OCR" if you read the date from the receipt itself, or "PHOTO_FALLBACK" if you used the fallback "${photoDateStr}" because the date was unreadable. Always include this field.
 - "description": merchant name + short summary of purchase (max 100 chars).
 - "multiCategory": true if the receipt contains items that span 2 or more DIFFERENT categories from the list below, false if all items belong to a single category. For example, a grocery receipt with food AND cleaning supplies = true, a restaurant bill with only food = false, a single ride receipt = false.
 - "breakdown": ONLY include this field when "multiCategory" is true. Read every line item on the receipt and group them by category. Each entry has: "amount" (sum for that category), "categoryId", "description" (store name + category + 1-2 sample items, max 80 chars), and "lineItems" (array of {"name": "<item name>", "amount": <price>}). The sum of all breakdown amounts should approximately equal the receipt total. Distribute tax/service proportionally or into the largest group. Do NOT include breakdown when multiCategory is false.
@@ -170,9 +171,9 @@ CATEGORY RULES (pick categoryId by matching the merchant/items to these rules):
 11. When in doubt about a food-adjacent item (e.g. plastic wrap, aluminum foil), put it in Household.
 
 Respond with ONLY valid JSON, no markdown or explanation:
-{"amount": <number>, "categoryId": "<id>", "date": "<YYYY-MM-DD>", "description": "<text>", "multiCategory": <boolean>}
+{"amount": <number>, "categoryId": "<id>", "date": "<YYYY-MM-DD>", "dateSource": "OCR" | "PHOTO_FALLBACK", "description": "<text>", "multiCategory": <boolean>}
 or when multiCategory is true:
-{"amount": <number>, "categoryId": "<id>", "date": "<YYYY-MM-DD>", "description": "<text>", "multiCategory": true, "breakdown": [{"amount": <number>, "categoryId": "<id>", "description": "<text>", "lineItems": [{"name": "<text>", "amount": <number>}]}]}`;
+{"amount": <number>, "categoryId": "<id>", "date": "<YYYY-MM-DD>", "dateSource": "OCR" | "PHOTO_FALLBACK", "description": "<text>", "multiCategory": true, "breakdown": [{"amount": <number>, "categoryId": "<id>", "description": "<text>", "lineItems": [{"name": "<text>", "amount": <number>}]}]}`;
 
     const response = await gemini.models.generateContent({
       model: GEMINI_MODEL,
@@ -237,7 +238,9 @@ or when multiCategory is true:
     }
 
     // Normalize date and flag suspicious year for the UI
-    const { date: normalizedDate, dateWarning, usedPhotoFallback } = checkReceiptDate(result.data.date, todayStr, photoDateStr);
+    const { date: normalizedDate, dateWarning, usedPhotoFallback: parseFailed } = checkReceiptDate(result.data.date, todayStr, photoDateStr);
+    // Trust Gemini's explicit signal first; fall back to parse-failure detection.
+    const usedPhotoFallback = result.data.dateSource === "PHOTO_FALLBACK" || parseFailed;
     result.data.date = normalizedDate;
 
     // Verify the categoryId actually exists in user's categories

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -95,10 +95,10 @@ export function AppShell({ children }: AppShellProps) {
     setScanError(null);
 
     try {
-      // Capture photoDate BEFORE compression — canvas re-encoding loses File metadata
-      const photoDate = toLocalDateString(
-        file.lastModified ? new Date(file.lastModified) : new Date()
-      );
+      // Capture photo timestamp BEFORE compression — canvas re-encoding loses File metadata
+      const photoMoment = file.lastModified ? new Date(file.lastModified) : new Date();
+      const photoDate = toLocalDateString(photoMoment);
+      const photoDateTime = formatDateInput(photoMoment);
       const compressed = await compressImage(file);
       const formData = new FormData();
       formData.append("receipt", compressed);
@@ -129,7 +129,7 @@ export function AppShell({ children }: AppShellProps) {
             amount: data.amount,
             description: data.description,
             type: data.type,
-            date: withLocalTime(data.date),
+            date: data.usedPhotoFallback ? photoDateTime : withLocalTime(data.date),
             categoryId: data.categoryId,
             multiCategory: data.multiCategory,
             breakdown: data.breakdown,
@@ -174,10 +174,10 @@ export function AppShell({ children }: AppShellProps) {
       setMultiScanItems(initialItems);
       setShowMultiScanReview(true);
 
-      // Capture photoDate per file BEFORE compression — canvas re-encoding loses File metadata
-      const photoDates = files.map((f) =>
-        toLocalDateString(f.lastModified ? new Date(f.lastModified) : new Date())
-      );
+      // Capture photo timestamps per file BEFORE compression — canvas re-encoding loses File metadata
+      const photoMoments = files.map((f) => (f.lastModified ? new Date(f.lastModified) : new Date()));
+      const photoDates = photoMoments.map(toLocalDateString);
+      const photoDateTimes = photoMoments.map(formatDateInput);
 
       // Compress all files in parallel (client-side only, no API cost)
       const compressed = await Promise.all(
@@ -228,7 +228,7 @@ export function AppShell({ children }: AppShellProps) {
                         amount: data.amount,
                         description: data.description,
                         type: data.type,
-                        date: withLocalTime(data.date),
+                        date: data.usedPhotoFallback ? photoDateTimes[i] : withLocalTime(data.date),
                         categoryId: data.categoryId,
                         multiCategory: data.multiCategory,
                         breakdown: data.breakdown,
@@ -375,13 +375,12 @@ export function AppShell({ children }: AppShellProps) {
       const formData = new FormData();
       formData.append("receipt", item.imageFile);
       formData.append("localDate", toLocalDateString(new Date()));
-      // Photo date sourced from the compressed file's preserved lastModified
-      formData.append(
-        "photoDate",
-        toLocalDateString(
-          item.imageFile.lastModified ? new Date(item.imageFile.lastModified) : new Date()
-        )
-      );
+      // Photo timestamp sourced from the compressed file's preserved lastModified
+      const photoMoment = item.imageFile.lastModified
+        ? new Date(item.imageFile.lastModified)
+        : new Date();
+      const photoDateTime = formatDateInput(photoMoment);
+      formData.append("photoDate", toLocalDateString(photoMoment));
 
       const res = await fetch("/api/receipts/breakdown", {
         method: "POST",
@@ -398,7 +397,8 @@ export function AppShell({ children }: AppShellProps) {
         return;
       }
 
-      expandBreakdown(id, item.fileName, withLocalTime(data.date), data.items, data.dateWarning);
+      const finalDate = data.usedPhotoFallback ? photoDateTime : withLocalTime(data.date);
+      expandBreakdown(id, item.fileName, finalDate, data.items, data.dateWarning);
 
       // Increment local scan count (breakdown = 1 additional credit)
       setUser((prev) => ({ scansUsedThisMonth: prev.scansUsedThisMonth + 1 }));

--- a/src/lib/receipt-date.ts
+++ b/src/lib/receipt-date.ts
@@ -15,10 +15,16 @@ export const checkReceiptDate = (
   dateStr: string,
   todayStr: string,
   photoFallback: string,
-): { date: string; dateWarning: boolean } => {
+): { date: string; dateWarning: boolean; usedPhotoFallback: boolean } => {
   const dateOnly = dateStr.slice(0, 10); // normalize "2024-03-14T13:45" → "2024-03-14"
   const parsed = new Date(dateOnly + "T00:00:00");
-  if (isNaN(parsed.getTime())) return { date: photoFallback, dateWarning: false };
+  if (isNaN(parsed.getTime())) {
+    return { date: photoFallback, dateWarning: false, usedPhotoFallback: true };
+  }
   const todayYear = new Date(todayStr + "T00:00:00").getFullYear();
-  return { date: dateOnly, dateWarning: parsed.getFullYear() !== todayYear };
+  return {
+    date: dateOnly,
+    dateWarning: parsed.getFullYear() !== todayYear,
+    usedPhotoFallback: false,
+  };
 };

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -90,8 +90,9 @@ export const receiptBreakdownItemSchema = z.object({
 });
 
 /** Signal from Gemini distinguishing "date read off the receipt" from "date is the photo-fallback we instructed".
- *  Defaults to OCR for back-compat when older models omit the field. */
-const dateSourceSchema = z.enum(["OCR", "PHOTO_FALLBACK"]).default("OCR");
+ *  Required: a missing field would silently default to OCR and re-mask the photo-fallback path,
+ *  so we'd rather reject the response (422) than silently drop it. */
+const dateSourceSchema = z.enum(["OCR", "PHOTO_FALLBACK"]);
 
 export const receiptBreakdownResultSchema = z.object({
   date: z.string().min(1),

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -89,8 +89,13 @@ export const receiptBreakdownItemSchema = z.object({
   lineItems: z.array(receiptBreakdownLineItemSchema).min(1).max(50),
 });
 
+/** Signal from Gemini distinguishing "date read off the receipt" from "date is the photo-fallback we instructed".
+ *  Defaults to OCR for back-compat when older models omit the field. */
+const dateSourceSchema = z.enum(["OCR", "PHOTO_FALLBACK"]).default("OCR");
+
 export const receiptBreakdownResultSchema = z.object({
   date: z.string().min(1),
+  dateSource: dateSourceSchema,
   items: z.array(receiptBreakdownItemSchema).min(1).max(20),
 });
 
@@ -98,6 +103,7 @@ export const receiptScanResultSchema = z.object({
   amount: z.number().positive(),
   categoryId: z.string().min(1),
   date: z.string().min(1),
+  dateSource: dateSourceSchema,
   description: z.string().max(255),
   type: z.literal("EXPENSE"),
   multiCategory: z.boolean(),


### PR DESCRIPTION
Closes #72

## Summary
Follow-up to #71. When the server falls back to the photo's date (because Gemini couldn't read the receipt date), also propagate the photo's **time-of-day** instead of substituting the user's current local time at review.

## Changes
- `src/lib/receipt-date.ts` — `checkReceiptDate` now returns `usedPhotoFallback: boolean` so the client can tell which path the server took.
- `src/app/api/receipts/scan/route.ts` and `src/app/api/receipts/breakdown/route.ts` — include `usedPhotoFallback` in the JSON response.
- `src/components/app-shell.tsx` — track `photoDateTime` (from `File.lastModified`) per item alongside the existing `photoDate`. When `usedPhotoFallback` is true, set the transaction datetime to `photoDateTime` instead of `withLocalTime(data.date)`. Applied to single-scan, multi-scan, and the `/api/receipts/breakdown` fallback path.

## Behavior matrix
| Gemini date                        | Date           | Time-of-day            |
|------------------------------------|----------------|------------------------|
| Parseable, current year            | OCR date       | current local (unchanged) |
| Parseable, year ≠ today            | OCR date + ⚠   | current local (unchanged) |
| Unparseable                        | photo date      | **photo time** (new)    |

## Regression guardrails
- `usedPhotoFallback` defaults to falsy on older clients — they ignore the field and behavior is identical to today.
- No schema or DB change.
- Year-mismatch path is untouched, so cross-year OCR scans (#71 review feedback) still keep the OCR date and current local time.
- Lint + type-check pass.

## Test plan
- [ ] Scan a clear current-year receipt → date and time match prior behavior.
- [ ] Scan a receipt where Gemini can't read the date → date and time both come from the photo's `lastModified`.
- [ ] Force a wrong-year scenario → ⚠ shows; date stays as OCR; time stays current local.
- [ ] Multi-scan with mixed receipts → each item gets its own correct datetime.
- [ ] Itemize via the `/api/receipts/breakdown` fallback path → same datetime rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scan and breakdown responses now include a dateSource and a usedPhotoFallback flag so the UI can indicate whether the date came from OCR or a photo metadata fallback.
  * Per-file photo timestamps are preserved for single and multi-file scans and propagated into breakdowns to ensure accurate dates when fallbacks are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->