### PR TITLE
chore(security): harden pnpm against supply-chain attacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pnpm version is read from the "packageManager" field in package.json.
+      # It must stay >=10.16 so the .npmrc hardening (minimum-release-age,
+      # block-exotic-subdeps) is actually enforced here.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+# Supply-chain hardening (see issue #74)
+# Quarantine newly-published packages for 7 days (10080 minutes).
+# Most malicious versions are caught and unpublished well within this window.
+minimum-release-age=10080
+
+# Block transitive deps from using non-registry specifiers (git:, github:, tarball URLs).
+# This was the exact injection vector in the @tanstack/router* attack (TanStack/router#7383).
+block-exotic-subdeps=true

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "packageManager": "pnpm@10.32.1",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "prisma generate && prisma migrate deploy && next build",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,26 @@
   "lint-staged": {
     "*.{ts,tsx}": "eslint --max-warnings 0"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@prisma/client",
+      "prisma",
+      "@prisma/engines",
+      "sharp",
+      "@img/sharp-darwin-arm64",
+      "@img/sharp-darwin-x64",
+      "@img/sharp-linux-arm",
+      "@img/sharp-linux-arm64",
+      "@img/sharp-linux-x64",
+      "@img/sharp-linuxmusl-arm64",
+      "@img/sharp-linuxmusl-x64",
+      "@img/sharp-win32-arm64",
+      "@img/sharp-win32-x64",
+      "@next/swc",
+      "esbuild",
+      "bcrypt"
+    ]
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@types/bcryptjs": "^2.4.6",


### PR DESCRIPTION
Adds three pnpm safeguards prompted by the @tanstack/router* npm compromise (TanStack/router#7383):

- minimum-release-age=10080 quarantines new versions for 7 days
- block-exotic-subdeps=true blocks transitive git:/tarball specifiers (the exact vector used in the TanStack attack)
- pnpm.onlyBuiltDependencies allowlists which packages may run install scripts (prisma, sharp + platform binaries, @next/swc, esbuild, bcrypt)

Refs: #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm configuration to enforce a minimum release age for new packages and prevent non-registry sources in transitive dependencies.
  * Configured package manager settings to specify which dependencies are allowed to be built during installation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisgen19/budget-tracker-2026/pull/75)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->