### PR TITLE
fix(receipts): retry Gemini 503/429 errors + surface honest scan errors

### DIFF
--- a/src/app/api/receipts/breakdown/route.ts
+++ b/src/app/api/receipts/breakdown/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { gemini, GEMINI_MODEL } from "@/lib/gemini";
+import { GEMINI_MODEL, generateContentWithRetry, isGeminiOverloaded } from "@/lib/gemini";
 import { getAuthUserId } from "@/lib/session";
 import { receiptBreakdownResultSchema } from "@/lib/validations";
 import { parseLocalDate, checkReceiptDate } from "@/lib/receipt-date";
@@ -174,7 +174,7 @@ RULES:
 - All amounts must be positive numbers
 - Do NOT include tax/service charge as a separate item — distribute proportionally or include in the largest group`;
 
-    const response = await gemini.models.generateContent({
+    const response = await generateContentWithRetry({
       model: GEMINI_MODEL,
       contents: [
         {
@@ -254,7 +254,14 @@ RULES:
     prisma.scanLog.create({ data: { userId } }).catch(() => {});
 
     return NextResponse.json({ ...result.data, dateWarning, usedPhotoFallback });
-  } catch {
+  } catch (error) {
+    console.error("[receipts/breakdown] Breakdown failed:", error);
+    if (isGeminiOverloaded(error)) {
+      return NextResponse.json(
+        { error: "The AI scanning service is busy right now. Please try again in a minute." },
+        { status: 503 }
+      );
+    }
     return NextResponse.json(
       { error: "Failed to break down receipt. Please try again." },
       { status: 500 }

--- a/src/app/api/receipts/scan/route.ts
+++ b/src/app/api/receipts/scan/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { gemini, GEMINI_MODEL } from "@/lib/gemini";
+import { GEMINI_MODEL, generateContentWithRetry, isGeminiOverloaded } from "@/lib/gemini";
 import { getAuthUserId } from "@/lib/session";
 import { receiptScanResultSchema } from "@/lib/validations";
 import { parseLocalDate, checkReceiptDate } from "@/lib/receipt-date";
@@ -175,7 +175,7 @@ Respond with ONLY valid JSON, no markdown or explanation:
 or when multiCategory is true:
 {"amount": <number>, "categoryId": "<id>", "date": "<YYYY-MM-DD>", "dateSource": "OCR" | "PHOTO_FALLBACK", "description": "<text>", "multiCategory": true, "breakdown": [{"amount": <number>, "categoryId": "<id>", "description": "<text>", "lineItems": [{"name": "<text>", "amount": <number>}]}]}`;
 
-    const response = await gemini.models.generateContent({
+    const response = await generateContentWithRetry({
       model: GEMINI_MODEL,
       contents: [
         {
@@ -265,7 +265,14 @@ or when multiCategory is true:
     prisma.scanLog.create({ data: { userId } }).catch(() => {});
 
     return NextResponse.json({ ...result.data, dateWarning, usedPhotoFallback });
-  } catch {
+  } catch (error) {
+    console.error("[receipts/scan] Scan failed:", error);
+    if (isGeminiOverloaded(error)) {
+      return NextResponse.json(
+        { error: "The AI scanning service is busy right now. Please try again in a minute." },
+        { status: 503 }
+      );
+    }
     return NextResponse.json(
       { error: "Failed to scan receipt. Please try again." },
       { status: 500 }

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -63,6 +63,7 @@ const MOBILE_NAV_ITEMS = NAV_ITEMS.filter((item) => item.href !== "/labels");
 export function AppShell({ children }: AppShellProps) {
   const pathname = usePathname();
   const { user, setUser } = useUser();
+  const { showToast } = useToast();
   const batchCreateMutation = useBatchCreateTransactions();
   const createTransactionMutation = useCreateTransaction();
   const billActionMutation = useBillAction();
@@ -390,10 +391,11 @@ export function AppShell({ children }: AppShellProps) {
       const data = await res.json();
 
       if (!res.ok) {
-        // Revert to success on error
+        // Revert to success (keeps the scanned data savable) and surface the reason
         setMultiScanItems((prev) =>
           prev.map((i) => (i.id === id ? { ...i, status: "success" as const } : i))
         );
+        showToast(data.error ?? "Failed to itemize receipt. Please try again.", "error");
         return;
       }
 
@@ -403,10 +405,11 @@ export function AppShell({ children }: AppShellProps) {
       // Increment local scan count (breakdown = 1 additional credit)
       setUser((prev) => ({ scansUsedThisMonth: prev.scansUsedThisMonth + 1 }));
     } catch {
-      // Revert to success on network error
+      // Revert to success on network error and surface the reason
       setMultiScanItems((prev) =>
         prev.map((i) => (i.id === id ? { ...i, status: "success" as const } : i))
       );
+      showToast("Network error. Please check your connection and try again.", "error");
     }
   };
 
@@ -458,8 +461,6 @@ export function AppShell({ children }: AppShellProps) {
     setMultiScanItems([]);
     setEditingItemId(null);
   };
-
-  const { showToast } = useToast();
 
   const handleBillPayAndEditSubmit = async (input: TransactionInput) => {
     const newTx = await createTransactionMutation.mutateAsync(input);

--- a/src/components/multi-scan-review.tsx
+++ b/src/components/multi-scan-review.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Pencil, Trash2, AlertCircle, CheckCircle2, Loader2, Rows3 } from "lucide-react";
 import { CategoryIcon } from "@/components/ui/icon-map";
+import { ReceiptBreakdown } from "@/components/transactions/receipt-breakdown";
 import { formatCurrency, cn } from "@/lib/utils";
 import { useUser } from "@/components/user-provider";
 import type { Category, MultiScanItem } from "@/types";
@@ -152,90 +153,101 @@ export function MultiScanReview({
           return (
             <div
               key={item.id}
-              className="flex items-center gap-3 p-4 rounded-xl border border-cream-200 bg-white"
+              className="p-4 rounded-xl border border-cream-200 bg-white space-y-3"
             >
-              {/* Category icon */}
-              <div
-                className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
-                style={{
-                  backgroundColor: category ? category.color + "18" : "#f5f0eb",
-                }}
-              >
-                {category ? (
-                  <CategoryIcon
-                    name={category.icon}
-                    className="w-5 h-5"
-                    style={{ color: category.color }}
-                  />
-                ) : (
-                  <CheckCircle2 className="w-5 h-5 text-income" />
-                )}
-              </div>
-
-              {/* Details */}
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-1.5">
-                  <p className="text-sm font-medium text-warm-700 truncate">
-                    {item.data?.description || "No description"}
-                  </p>
-                  {isItemizedChild && (
-                    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-light/60 text-amber-dark shrink-0">
-                      Itemized
-                    </span>
+              <div className="flex items-center gap-3">
+                {/* Category icon */}
+                <div
+                  className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+                  style={{
+                    backgroundColor: category ? category.color + "18" : "#f5f0eb",
+                  }}
+                >
+                  {category ? (
+                    <CategoryIcon
+                      name={category.icon}
+                      className="w-5 h-5"
+                      style={{ color: category.color }}
+                    />
+                  ) : (
+                    <CheckCircle2 className="w-5 h-5 text-income" />
                   )}
                 </div>
-                <div className="flex items-center gap-2 mt-0.5">
-                  {category && (
-                    <span className="text-xs text-warm-400">{category.name}</span>
-                  )}
-                  {category && formattedDate && (
-                    <span className="text-xs text-warm-200">&middot;</span>
-                  )}
-                  {formattedDate && (
-                    <span className={cn("text-xs", item.data?.dateWarning ? "text-amber-600 font-medium" : "text-warm-400")}>
-                      {item.data?.dateWarning && "⚠ "}{formattedDate}
-                      {item.data?.dateWarning && (
-                        <span className="text-[10px] text-amber-500 ml-1">(check year)</span>
-                      )}
-                    </span>
-                  )}
+
+                {/* Details */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <p className="text-sm font-medium text-warm-700 truncate">
+                      {item.data?.description || "No description"}
+                    </p>
+                    {isItemizedChild && (
+                      <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-light/60 text-amber-dark shrink-0">
+                        Itemized
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 mt-0.5">
+                    {category && (
+                      <span className="text-xs text-warm-400">{category.name}</span>
+                    )}
+                    {category && formattedDate && (
+                      <span className="text-xs text-warm-200">&middot;</span>
+                    )}
+                    {formattedDate && (
+                      <span className={cn("text-xs", item.data?.dateWarning ? "text-amber-600 font-medium" : "text-warm-400")}>
+                        {item.data?.dateWarning && "⚠ "}{formattedDate}
+                        {item.data?.dateWarning && (
+                          <span className="text-[10px] text-amber-500 ml-1">(check year)</span>
+                        )}
+                      </span>
+                    )}
+                  </div>
                 </div>
-              </div>
 
-              {/* Amount */}
-              <p className="text-sm font-semibold text-warm-700 tabular-nums shrink-0">
-                {item.data?.amount
-                  ? formatCurrency(item.data.amount, user.currency)
-                  : "—"}
-              </p>
+                {/* Amount */}
+                <p className="text-sm font-semibold text-warm-700 tabular-nums shrink-0">
+                  {item.data?.amount
+                    ? formatCurrency(item.data.amount, user.currency)
+                    : "—"}
+                </p>
 
-              {/* Actions */}
-              <div className="flex items-center gap-1 shrink-0">
-                {canItemize && (
+                {/* Actions */}
+                <div className="flex items-center gap-1 shrink-0">
+                  {canItemize && (
+                    <button
+                      type="button"
+                      onClick={() => onItemize(item.id)}
+                      title="Itemize receipt"
+                      className="p-2 rounded-lg text-warm-300 hover:text-amber hover:bg-amber-light transition-colors"
+                    >
+                      <Rows3 className="w-4 h-4" />
+                    </button>
+                  )}
                   <button
                     type="button"
-                    onClick={() => onItemize(item.id)}
-                    title="Itemize receipt"
-                    className="p-2 rounded-lg text-warm-300 hover:text-amber hover:bg-amber-light transition-colors"
+                    onClick={() => onEdit(item.id)}
+                    className="p-2 rounded-lg text-warm-300 hover:text-amber-dark hover:bg-amber-light transition-colors"
                   >
-                    <Rows3 className="w-4 h-4" />
+                    <Pencil className="w-4 h-4" />
                   </button>
-                )}
-                <button
-                  type="button"
-                  onClick={() => onEdit(item.id)}
-                  className="p-2 rounded-lg text-warm-300 hover:text-amber-dark hover:bg-amber-light transition-colors"
-                >
-                  <Pencil className="w-4 h-4" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => onRemove(item.id)}
-                  className="p-2 rounded-lg text-warm-300 hover:text-expense hover:bg-expense-light transition-colors"
-                >
-                  <Trash2 className="w-4 h-4" />
-                </button>
+                  <button
+                    type="button"
+                    onClick={() => onRemove(item.id)}
+                    className="p-2 rounded-lg text-warm-300 hover:text-expense hover:bg-expense-light transition-colors"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
               </div>
+
+              {/* Line items from itemized receipts — collapsed to keep the list compact */}
+              {item.data?.receiptBreakdown && (
+                <ReceiptBreakdown
+                  breakdown={item.data.receiptBreakdown}
+                  currency={user.currency}
+                  defaultExpanded={false}
+                />
+              )}
             </div>
           );
         })}

--- a/src/components/transactions/receipt-breakdown.tsx
+++ b/src/components/transactions/receipt-breakdown.tsx
@@ -8,10 +8,12 @@ import type { ReceiptBreakdownMeta } from "@/types";
 interface ReceiptBreakdownProps {
   breakdown: ReceiptBreakdownMeta;
   currency: string;
+  /** Initial expanded state — defaults to open (transaction form); lists may start collapsed */
+  defaultExpanded?: boolean;
 }
 
-export function ReceiptBreakdown({ breakdown, currency }: ReceiptBreakdownProps) {
-  const [expanded, setExpanded] = useState(true);
+export function ReceiptBreakdown({ breakdown, currency, defaultExpanded = true }: ReceiptBreakdownProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
 
   return (
     <div className="rounded-xl border border-cream-200 bg-cream-50/60">

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -28,15 +28,12 @@ export const generateContentWithRetry = async (
   params: GenerateContentParameters,
   maxAttempts = 3
 ) => {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+  for (let attempt = 1; ; attempt++) {
     try {
       return await gemini.models.generateContent(params);
     } catch (error) {
-      lastError = error;
-      if (!isGeminiOverloaded(error) || attempt === maxAttempts) throw error;
+      if (!isGeminiOverloaded(error) || attempt >= maxAttempts) throw error;
       await sleep(attempt * 1000);
     }
   }
-  throw lastError; // unreachable — loop always returns or throws
 };

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,4 +1,4 @@
-import { GoogleGenAI } from "@google/genai";
+import { ApiError, GoogleGenAI, type GenerateContentParameters } from "@google/genai";
 
 const globalForGemini = globalThis as unknown as {
   gemini: GoogleGenAI | undefined;
@@ -10,3 +10,33 @@ export const gemini =
 if (process.env.NODE_ENV !== "production") globalForGemini.gemini = gemini;
 
 export const GEMINI_MODEL = process.env.GEMINI_MODEL ?? "gemini-2.5-flash";
+
+/** Transient Gemini errors worth retrying: 429 (rate limit) and 503 (model overloaded) */
+const RETRYABLE_STATUSES = new Set([429, 503]);
+
+/** True when Gemini rejected the call due to temporary overload or rate limiting */
+export const isGeminiOverloaded = (error: unknown): boolean =>
+  error instanceof ApiError && RETRYABLE_STATUSES.has(error.status);
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Call Gemini with automatic retries on transient 429/503 errors.
+ * Backs off 1s, then 2s between attempts. Non-retryable errors are rethrown immediately.
+ */
+export const generateContentWithRetry = async (
+  params: GenerateContentParameters,
+  maxAttempts = 3
+) => {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await gemini.models.generateContent(params);
+    } catch (error) {
+      lastError = error;
+      if (!isGeminiOverloaded(error) || attempt === maxAttempts) throw error;
+      await sleep(attempt * 1000);
+    }
+  }
+  throw lastError; // unreachable — loop always returns or throws
+};


### PR DESCRIPTION
## Summary

Fixes #76

Two changes around receipt scanning:

1. **Fix:** receipt scans were intermittently failing with **"Failed to scan receipt. Please try again."** for valid photos. Root cause (verified by replaying the exact route request): `gemini-2.5-flash` intermittently returns **503 UNAVAILABLE** ("model is currently experiencing high demand"), and both receipt routes swallowed every exception in a bare `catch {}` — no logging, and a generic 500 message implying the *receipt* was the problem.
2. **Feature:** after itemizing a multi-category receipt in **Review Scanned Receipts**, each per-category item now shows a collapsible **Receipt Breakdown** with its individual line items.

## Changes

### Gemini 503 retry + honest errors
- **`src/lib/gemini.ts`** — new `generateContentWithRetry()`: retries transient 429/503 Gemini errors up to 3 attempts with 1s/2s backoff; non-retryable errors rethrow immediately. New `isGeminiOverloaded()` guard for error mapping.
- **`src/app/api/receipts/scan/route.ts`** + **`src/app/api/receipts/breakdown/route.ts`**:
  - Gemini calls go through the retry wrapper
  - Overload errors now return **503** with "The AI scanning service is busy right now. Please try again in a minute." instead of a generic 500
  - Errors are logged via `console.error` so they're visible in Coolify logs
- No client changes needed — both scan flows already display `data.error` from the response.

### Receipt Breakdown in scan review
- **`src/components/transactions/receipt-breakdown.tsx`** — new optional `defaultExpanded` prop (defaults `true`, so the transaction form keeps its open-by-default behavior).
- **`src/components/multi-scan-review.tsx`** — itemized items (those carrying `data.receiptBreakdown` after clicking the Itemize button) render the reused `ReceiptBreakdown` component below the row, collapsed by default to keep the review list compact. Tap "Receipt Breakdown" to expand line items + total.

## Test plan

- [x] `pnpm lint` + `pnpm type-check` pass
- [x] Reproduced the original failure: replayed the route's exact Gemini request with the reported HEIC receipt → got 503 UNAVAILABLE twice in a row
- [x] Verified the fix live: `generateContentWithRetry` with the same image succeeded ("South Supermarket - Pasig, 4,240.80") during the same overload window
- [ ] Manual: scan a multi-category receipt → tap Itemize → each per-category item shows a collapsed "Receipt Breakdown (N items)" section that expands to line items with a total footer
- [ ] Manual: edit/remove/save-all still work on itemized items; transaction form's breakdown still opens expanded

## Follow-up (out of scope)

- Optional fallback model (e.g. `gemini-2.0-flash`) when 2.5-flash stays overloaded past retries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core receipt OCR API paths and external Gemini calls (retries may increase latency and API usage during outages); UI changes are limited to scan review and error messaging.
> 
> **Overview**
> Receipt scanning now **retries transient Gemini 429/503 failures** via `generateContentWithRetry` in `gemini.ts`, and both **`/api/receipts/scan`** and **`/api/receipts/breakdown`** log failures and return **503** with a clear “AI service is busy” message when overload persists instead of a generic 500.
> 
> In **Review Scanned Receipts**, itemized per-category rows show a **collapsible Receipt Breakdown** (reused component, collapsed by default). **`ReceiptBreakdown`** gains optional `defaultExpanded` so the transaction form stays expanded by default.
> 
> **Itemize** failures in multi-scan now **toast** the API/network error while reverting the row to a savable success state (`app-shell.tsx`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c93d714b28194fe05aa46f7e5c30e2388d55fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->