### PR TITLE
perf(receipts): faster scans — disable Gemini thinking, JSON mode, pipelined uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,19 @@ EMAIL_FROM="Budget Tracker <noreply@yourdomain.com>"
 # Google Gemini (receipt scanning OCR)
 GEMINI_API_KEY=""
 GEMINI_MODEL="gemini-2.5-flash"
-# Thinking budget for receipt scans: 0 = off (fastest, recommended for OCR),
-# -1 = dynamic thinking (model decides), 128-24576 = fixed token budget
+# Fallback model tried once when GEMINI_MODEL stays overloaded (503) after retries.
+# Set to "" to disable fallback.
+GEMINI_FALLBACK_MODEL="gemini-2.5-flash"
+# Thinking for receipt scans — the right knob depends on the model generation:
+# Gemini 2.x (thinkingBudget): 0 = off (fastest, recommended for OCR),
+#   -1 = dynamic thinking, 128-24576 = fixed token budget
 GEMINI_THINKING_BUDGET="0"
+# Gemini 3+ (thinkingLevel): minimal (fastest, recommended for OCR) | low | medium | high
+GEMINI_THINKING_LEVEL="minimal"
+# Per-attempt timeout in ms — overloaded attempts can hang 40-70s before failing;
+# aborting early lets retries/fallback kick in sooner. 0 disables the timeout.
+# Raise this if you enable deeper thinking (dynamic budget or medium/high level).
+GEMINI_TIMEOUT_MS="30000"
 
 # Cron job authentication — shared with the GitHub Actions workflow that triggers
 # /api/cron/bill-reminders daily on production. Set the same value in the deploy

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ EMAIL_FROM="Budget Tracker <noreply@yourdomain.com>"
 # Google Gemini (receipt scanning OCR)
 GEMINI_API_KEY=""
 GEMINI_MODEL="gemini-2.5-flash"
+# Thinking budget for receipt scans: 0 = off (fastest, recommended for OCR),
+# -1 = dynamic thinking (model decides), 128-24576 = fixed token budget
+GEMINI_THINKING_BUDGET="0"
 
 # Cron job authentication — shared with the GitHub Actions workflow that triggers
 # /api/cron/bill-reminders daily on production. Set the same value in the deploy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ src/
 - `DATABASE_URL` — PostgreSQL connection string
 - `NEXTAUTH_SECRET` / `NEXTAUTH_URL` — NextAuth session config
 - `GEMINI_API_KEY` — Google Gemini AI for receipt scanning
+- `GEMINI_MODEL` — Optional; Gemini model for receipt scanning (defaults to `gemini-2.5-flash`)
+- `GEMINI_THINKING_BUDGET` — Optional; thinking budget for receipt scans. `0` = off (fastest, default, recommended for OCR), `-1` = dynamic thinking, `128`-`24576` = fixed token budget
 - `RESEND_API_KEY` — Email sending (verification + password reset)
 - `EMAIL_FROM` — Sender address (optional; defaults to `Budget Tracker <noreply@resend.dev>` if unset). Use a verified Resend domain in production, e.g. `Budget Tracker <noreply@yourdomain.com>`.
 - `AUTH_URL` — Optional; used in preview/staging deployments

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,10 @@ src/
 - `NEXTAUTH_SECRET` / `NEXTAUTH_URL` — NextAuth session config
 - `GEMINI_API_KEY` — Google Gemini AI for receipt scanning
 - `GEMINI_MODEL` — Optional; Gemini model for receipt scanning (defaults to `gemini-2.5-flash`)
-- `GEMINI_THINKING_BUDGET` — Optional; thinking budget for receipt scans. `0` = off (fastest, default, recommended for OCR), `-1` = dynamic thinking, `128`-`24576` = fixed token budget
+- `GEMINI_FALLBACK_MODEL` — Optional; model retried once when the primary stays overloaded (503) after retries (defaults to `gemini-2.5-flash`; `""` disables fallback)
+- `GEMINI_THINKING_BUDGET` — Optional; thinking budget for **Gemini 2.x** models. `0` = off (fastest, default, recommended for OCR), `-1` = dynamic thinking, `128`-`24576` = fixed token budget
+- `GEMINI_THINKING_LEVEL` — Optional; thinking level for **Gemini 3+** models (they use `thinkingLevel`, not `thinkingBudget`): `minimal` (fastest, default, recommended for OCR) | `low` | `medium` | `high`
+- `GEMINI_TIMEOUT_MS` — Optional; per-attempt request timeout in ms (default `30000`, `0` disables). Timed-out attempts are retried like 503s. Raise it when enabling deeper thinking
 - `RESEND_API_KEY` — Email sending (verification + password reset)
 - `EMAIL_FROM` — Sender address (optional; defaults to `Budget Tracker <noreply@resend.dev>` if unset). Use a verified Resend domain in production, e.g. `Budget Tracker <noreply@yourdomain.com>`.
 - `AUTH_URL` — Optional; used in preview/staging deployments

--- a/README.md
+++ b/README.md
@@ -95,11 +95,28 @@ NEXTAUTH_URL="http://localhost:3000"
 # Google Gemini (optional — enables receipt scanning)
 GEMINI_API_KEY=""
 GEMINI_MODEL="gemini-2.5-flash"
+
+# Gemini tuning (all optional — these are the defaults used when unset)
+GEMINI_FALLBACK_MODEL="gemini-2.5-flash"   # "" disables fallback
+GEMINI_THINKING_LEVEL="minimal"            # used by Gemini 3+ models
+GEMINI_THINKING_BUDGET="0"                 # used by Gemini 2.x models
+GEMINI_TIMEOUT_MS="30000"                  # per-attempt timeout; 0 disables
 ```
 
 > **Note:** Generate a secure `NEXTAUTH_SECRET` for production with `openssl rand -base64 32`
 >
 > **Receipt Scanning:** The `GEMINI_API_KEY` is only required if you enable the receipt scanning feature. Get one from [Google AI Studio](https://aistudio.google.com/apikey).
+
+#### Gemini tuning options
+
+All four are optional — when unset, the defaults shown above apply. The right thinking knob is picked automatically from the model generation.
+
+| Variable | Possible values | Notes |
+|---|---|---|
+| `GEMINI_FALLBACK_MODEL` | any Gemini model id, or `""` | Tried once when `GEMINI_MODEL` stays overloaded (503/504) after retries. `""` disables fallback. Fast alternative: `gemini-2.5-flash-lite` |
+| `GEMINI_THINKING_LEVEL` | `minimal` \| `low` \| `medium` \| `high` | **Gemini 3+ models only** (e.g. `gemini-3.5-flash`). `minimal` is fastest and recommended for OCR; `medium` is the model's own default |
+| `GEMINI_THINKING_BUDGET` | `0` \| `-1` \| `128`–`24576` | **Gemini 2.x models only** (e.g. `gemini-2.5-flash`). `0` = thinking off (fastest), `-1` = dynamic (model decides), number = fixed token budget. Valid range varies per model |
+| `GEMINI_TIMEOUT_MS` | milliseconds, or `0` | Aborts hung attempts so retry/fallback kicks in sooner; timed-out attempts are retried like 503s. `0` disables. Raise it (e.g. `60000`) if you enable deeper thinking |
 
 ### 4. Create the database and run migrations
 

--- a/src/app/api/receipts/breakdown/route.ts
+++ b/src/app/api/receipts/breakdown/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { GEMINI_MODEL, generateContentWithRetry, isGeminiOverloaded } from "@/lib/gemini";
+import { GEMINI_MODEL, RECEIPT_SCAN_CONFIG, generateContentWithRetry, isGeminiOverloaded } from "@/lib/gemini";
 import { getAuthUserId } from "@/lib/session";
 import { receiptBreakdownResultSchema } from "@/lib/validations";
 import { parseLocalDate, checkReceiptDate } from "@/lib/receipt-date";
@@ -190,6 +190,7 @@ RULES:
           ],
         },
       ],
+      config: RECEIPT_SCAN_CONFIG,
     });
 
     const rawText = response.text?.trim();

--- a/src/app/api/receipts/breakdown/route.ts
+++ b/src/app/api/receipts/breakdown/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { GEMINI_MODEL, RECEIPT_SCAN_CONFIG, generateContentWithRetry, isGeminiOverloaded } from "@/lib/gemini";
+import { GEMINI_MODEL, receiptScanConfig, generateContentWithRetry, isGeminiUnavailable } from "@/lib/gemini";
 import { getAuthUserId } from "@/lib/session";
 import { receiptBreakdownResultSchema } from "@/lib/validations";
 import { parseLocalDate, checkReceiptDate } from "@/lib/receipt-date";
@@ -190,7 +190,7 @@ RULES:
           ],
         },
       ],
-      config: RECEIPT_SCAN_CONFIG,
+      config: receiptScanConfig(),
     });
 
     const rawText = response.text?.trim();
@@ -257,7 +257,7 @@ RULES:
     return NextResponse.json({ ...result.data, dateWarning, usedPhotoFallback });
   } catch (error) {
     console.error("[receipts/breakdown] Breakdown failed:", error);
-    if (isGeminiOverloaded(error)) {
+    if (isGeminiUnavailable(error)) {
       return NextResponse.json(
         { error: "The AI scanning service is busy right now. Please try again in a minute." },
         { status: 503 }

--- a/src/app/api/receipts/scan/route.ts
+++ b/src/app/api/receipts/scan/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { GEMINI_MODEL, RECEIPT_SCAN_CONFIG, generateContentWithRetry, isGeminiOverloaded } from "@/lib/gemini";
+import { GEMINI_MODEL, receiptScanConfig, generateContentWithRetry, isGeminiUnavailable } from "@/lib/gemini";
 import { getAuthUserId } from "@/lib/session";
 import { receiptScanResultSchema } from "@/lib/validations";
 import { parseLocalDate, checkReceiptDate } from "@/lib/receipt-date";
@@ -191,7 +191,7 @@ or when multiCategory is true:
           ],
         },
       ],
-      config: RECEIPT_SCAN_CONFIG,
+      config: receiptScanConfig(),
     });
 
     const rawText = response.text?.trim();
@@ -268,7 +268,7 @@ or when multiCategory is true:
     return NextResponse.json({ ...result.data, dateWarning, usedPhotoFallback });
   } catch (error) {
     console.error("[receipts/scan] Scan failed:", error);
-    if (isGeminiOverloaded(error)) {
+    if (isGeminiUnavailable(error)) {
       return NextResponse.json(
         { error: "The AI scanning service is busy right now. Please try again in a minute." },
         { status: 503 }

--- a/src/app/api/receipts/scan/route.ts
+++ b/src/app/api/receipts/scan/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { GEMINI_MODEL, generateContentWithRetry, isGeminiOverloaded } from "@/lib/gemini";
+import { GEMINI_MODEL, RECEIPT_SCAN_CONFIG, generateContentWithRetry, isGeminiOverloaded } from "@/lib/gemini";
 import { getAuthUserId } from "@/lib/session";
 import { receiptScanResultSchema } from "@/lib/validations";
 import { parseLocalDate, checkReceiptDate } from "@/lib/receipt-date";
@@ -191,6 +191,7 @@ or when multiCategory is true:
           ],
         },
       ],
+      config: RECEIPT_SCAN_CONFIG,
     });
 
     const rawText = response.text?.trim();

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -180,19 +180,18 @@ export function AppShell({ children }: AppShellProps) {
       const photoDates = photoMoments.map(toLocalDateString);
       const photoDateTimes = photoMoments.map(formatDateInput);
 
-      // Compress all files in parallel (client-side only, no API cost)
-      const compressed = await Promise.all(
-        files.map((f) => compressImage(f).catch(() => f))
-      );
+      // Start compressing all files in parallel (client-side only, no API cost).
+      // Each upload starts as soon as its own compression finishes — no barrier.
+      const compressedPromises = files.map((f) => compressImage(f).catch(() => f));
 
-      // Process API calls with max 2 concurrent requests
+      // Process API calls with limited concurrency
       const CONCURRENCY = 3;
       let nextIndex = 0;
 
       const processNext = async (): Promise<void> => {
-        while (nextIndex < compressed.length) {
+        while (nextIndex < compressedPromises.length) {
           const i = nextIndex++;
-          const file = compressed[i];
+          const file = await compressedPromises[i];
           const itemId = initialItems[i].id;
 
           try {
@@ -257,7 +256,7 @@ export function AppShell({ children }: AppShellProps) {
 
       // Start concurrent workers
       await Promise.all(
-        Array.from({ length: Math.min(CONCURRENCY, compressed.length) }, () =>
+        Array.from({ length: Math.min(CONCURRENCY, compressedPromises.length) }, () =>
           processNext()
         )
       );

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -58,8 +58,11 @@ export const receiptScanConfig = (model: string = GEMINI_MODEL) => ({
   ...(GEMINI_TIMEOUT_MS > 0 && { httpOptions: { timeout: GEMINI_TIMEOUT_MS } }),
 });
 
-/** Transient Gemini errors worth retrying: 429 (rate limit) and 503 (model overloaded) */
-const RETRYABLE_STATUSES = new Set([429, 503]);
+/** Transient Gemini errors worth retrying, per Google's error guidance:
+ *  429 (rate limit), 500 (INTERNAL — unexpected error on Google's side),
+ *  503 (UNAVAILABLE — model overloaded), 504 (DEADLINE_EXCEEDED — Google's
+ *  server-side deadline expired before the request finished) */
+const RETRYABLE_STATUSES = new Set([429, 500, 503, 504]);
 
 /** True when Gemini rejected the call due to temporary overload or rate limiting */
 export const isGeminiOverloaded = (error: unknown): boolean =>

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,4 +1,4 @@
-import { ApiError, GoogleGenAI, type GenerateContentParameters } from "@google/genai";
+import { ApiError, GoogleGenAI, ThinkingLevel, type GenerateContentParameters, type ThinkingConfig } from "@google/genai";
 
 const globalForGemini = globalThis as unknown as {
   gemini: GoogleGenAI | undefined;
@@ -11,18 +11,52 @@ if (process.env.NODE_ENV !== "production") globalForGemini.gemini = gemini;
 
 export const GEMINI_MODEL = process.env.GEMINI_MODEL ?? "gemini-2.5-flash";
 
-/** Thinking budget for receipt extraction — 0 disables thinking (fastest, recommended for OCR),
+/** Model to retry on after the primary model exhausts its overload retries.
+ *  Set GEMINI_FALLBACK_MODEL="" to disable fallback entirely. */
+export const GEMINI_FALLBACK_MODEL =
+  process.env.GEMINI_FALLBACK_MODEL ?? "gemini-2.5-flash";
+
+/** Thinking budget for Gemini 2.x models — 0 disables thinking (fastest, recommended for OCR),
  *  -1 enables dynamic thinking (model decides), 128-24576 sets a fixed token budget.
  *  Configured via GEMINI_THINKING_BUDGET; defaults to 0. */
 const parsedThinkingBudget = Number.parseInt(process.env.GEMINI_THINKING_BUDGET ?? "", 10);
 export const GEMINI_THINKING_BUDGET = Number.isNaN(parsedThinkingBudget) ? 0 : parsedThinkingBudget;
 
-/** Shared generation config for receipt scanning: JSON-only responses (no markdown fences)
- *  + env-configurable thinking budget */
-export const RECEIPT_SCAN_CONFIG = {
+/** Thinking level for Gemini 3+ models (they use thinkingLevel, not thinkingBudget) —
+ *  "minimal" is fastest (recommended for OCR); "medium" is the model default for 3.5 Flash.
+ *  Configured via GEMINI_THINKING_LEVEL; defaults to minimal. */
+const THINKING_LEVELS: Record<string, ThinkingLevel> = {
+  minimal: ThinkingLevel.MINIMAL,
+  low: ThinkingLevel.LOW,
+  medium: ThinkingLevel.MEDIUM,
+  high: ThinkingLevel.HIGH,
+};
+export const GEMINI_THINKING_LEVEL =
+  THINKING_LEVELS[(process.env.GEMINI_THINKING_LEVEL ?? "minimal").toLowerCase()] ??
+  ThinkingLevel.MINIMAL;
+
+/** Per-attempt request timeout — overloaded Gemini attempts can hang 40-70s before
+ *  failing; aborting early lets retries/fallback kick in sooner.
+ *  Configured via GEMINI_TIMEOUT_MS; defaults to 30s. Raise it if you enable
+ *  deeper thinking (dynamic budget or medium/high level). */
+const parsedTimeout = Number.parseInt(process.env.GEMINI_TIMEOUT_MS ?? "", 10);
+export const GEMINI_TIMEOUT_MS = Number.isNaN(parsedTimeout) ? 30_000 : parsedTimeout;
+
+/** Pick the right thinking knob per model generation:
+ *  Gemini 1.x/2.x use thinkingBudget; Gemini 3+ use thinkingLevel
+ *  (thinkingBudget is only backwards-compat there and performs worse). */
+const thinkingConfigFor = (model: string): ThinkingConfig =>
+  /^gemini-[12]\./.test(model)
+    ? { thinkingBudget: GEMINI_THINKING_BUDGET }
+    : { thinkingLevel: GEMINI_THINKING_LEVEL };
+
+/** Generation config for receipt scanning: JSON-only responses (no markdown fences)
+ *  + env-configurable thinking matched to the model's generation + per-attempt timeout */
+export const receiptScanConfig = (model: string = GEMINI_MODEL) => ({
   responseMimeType: "application/json",
-  thinkingConfig: { thinkingBudget: GEMINI_THINKING_BUDGET },
-} as const;
+  thinkingConfig: thinkingConfigFor(model),
+  ...(GEMINI_TIMEOUT_MS > 0 && { httpOptions: { timeout: GEMINI_TIMEOUT_MS } }),
+});
 
 /** Transient Gemini errors worth retrying: 429 (rate limit) and 503 (model overloaded) */
 const RETRYABLE_STATUSES = new Set([429, 503]);
@@ -31,22 +65,60 @@ const RETRYABLE_STATUSES = new Set([429, 503]);
 export const isGeminiOverloaded = (error: unknown): boolean =>
   error instanceof ApiError && RETRYABLE_STATUSES.has(error.status);
 
+/** True when the request was aborted by the per-attempt timeout */
+const isTimeoutError = (error: unknown): boolean =>
+  error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+
+/** True when Gemini is temporarily unavailable: overloaded, rate limited, or unresponsive */
+export const isGeminiUnavailable = (error: unknown): boolean =>
+  isGeminiOverloaded(error) || isTimeoutError(error);
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-/**
- * Call Gemini with automatic retries on transient 429/503 errors.
- * Backs off 1s, then 2s between attempts. Non-retryable errors are rethrown immediately.
- */
-export const generateContentWithRetry = async (
+const attemptWithRetries = async (
   params: GenerateContentParameters,
-  maxAttempts = 3
+  maxAttempts: number
 ) => {
   for (let attempt = 1; ; attempt++) {
     try {
       return await gemini.models.generateContent(params);
     } catch (error) {
-      if (!isGeminiOverloaded(error) || attempt >= maxAttempts) throw error;
+      if (!isGeminiUnavailable(error) || attempt >= maxAttempts) throw error;
       await sleep(attempt * 1000);
     }
+  }
+};
+
+/**
+ * Call Gemini with automatic retries on transient 429/503 errors (1s, 2s backoff).
+ * If the primary model stays overloaded after all attempts, retries once on
+ * GEMINI_FALLBACK_MODEL (with thinking config rebuilt for that model) before
+ * giving up. Non-retryable errors are rethrown immediately.
+ */
+export const generateContentWithRetry = async (
+  params: GenerateContentParameters,
+  maxAttempts = 3
+) => {
+  try {
+    return await attemptWithRetries(params, maxAttempts);
+  } catch (error) {
+    if (
+      !isGeminiUnavailable(error) ||
+      !GEMINI_FALLBACK_MODEL ||
+      GEMINI_FALLBACK_MODEL === params.model
+    ) {
+      throw error;
+    }
+    console.warn(
+      `[gemini] ${String(params.model)} overloaded after ${maxAttempts} attempts — falling back to ${GEMINI_FALLBACK_MODEL}`
+    );
+    return attemptWithRetries(
+      {
+        ...params,
+        model: GEMINI_FALLBACK_MODEL,
+        config: { ...params.config, thinkingConfig: thinkingConfigFor(GEMINI_FALLBACK_MODEL) },
+      },
+      2
+    );
   }
 };

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -11,6 +11,19 @@ if (process.env.NODE_ENV !== "production") globalForGemini.gemini = gemini;
 
 export const GEMINI_MODEL = process.env.GEMINI_MODEL ?? "gemini-2.5-flash";
 
+/** Thinking budget for receipt extraction — 0 disables thinking (fastest, recommended for OCR),
+ *  -1 enables dynamic thinking (model decides), 128-24576 sets a fixed token budget.
+ *  Configured via GEMINI_THINKING_BUDGET; defaults to 0. */
+const parsedThinkingBudget = Number.parseInt(process.env.GEMINI_THINKING_BUDGET ?? "", 10);
+export const GEMINI_THINKING_BUDGET = Number.isNaN(parsedThinkingBudget) ? 0 : parsedThinkingBudget;
+
+/** Shared generation config for receipt scanning: JSON-only responses (no markdown fences)
+ *  + env-configurable thinking budget */
+export const RECEIPT_SCAN_CONFIG = {
+  responseMimeType: "application/json",
+  thinkingConfig: { thinkingBudget: GEMINI_THINKING_BUDGET },
+} as const;
+
 /** Transient Gemini errors worth retrying: 429 (rate limit) and 503 (model overloaded) */
 const RETRYABLE_STATUSES = new Set([429, 503]);
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -70,12 +70,10 @@ const isHeicFile = (file: File): boolean => {
 /**
  * Compress an image file by resizing to max 1500px and re-encoding as JPEG.
  * Reduces ~4 MB camera photos to ~200-400 KB for faster uploads.
- * HEIC/HEIF files are returned as-is since canvas can't decode them — Gemini handles HEIC natively.
+ * HEIC/HEIF decode works on Safari 17+ (OS codec); on browsers that can't decode it
+ * (Chrome/Firefox) the original file is returned as-is — Gemini handles HEIC natively.
  */
 export const compressImage = (file: File): Promise<File> => {
-  // HEIC/HEIF can't be decoded by canvas in most browsers — skip compression
-  if (isHeicFile(file)) return Promise.resolve(file);
-
   return new Promise((resolve, reject) => {
     const img = new Image();
     const url = URL.createObjectURL(file);
@@ -118,6 +116,11 @@ export const compressImage = (file: File): Promise<File> => {
 
     img.onerror = () => {
       URL.revokeObjectURL(url);
+      // HEIC decode is expected to fail outside Safari — upload the original instead
+      if (isHeicFile(file)) {
+        resolve(file);
+        return;
+      }
       reject(new Error("Failed to load image for compression"));
     };
 


### PR DESCRIPTION
## Summary

Speeds up receipt scanning end-to-end and makes it resilient to Gemini overload waves. The dominant cost was the Gemini call itself: **thinking is enabled by default** on both 2.5 and 3.x Flash models, adding 15-25s per scan — and the thinking capacity pool is what returns the 503s addressed in #77.

**Benchmarks** (real South Supermarket receipt, live overload windows):

| Model + config | Result |
|---|---|
| `gemini-2.5-flash` default (thinking) | 503'd 7/7 during overload |
| `gemini-2.5-flash` + `thinkingBudget: 0` | **7.5–8.9s**, succeeded through overload |
| `gemini-3.5-flash` default (medium thinking) | 27.4s, 538 thought tokens |
| `gemini-3.5-flash` + `thinkingBudget: 0` (wrong knob!) | 19.0s |
| `gemini-3.5-flash` + `thinkingLevel: MINIMAL` | **3.5s** |

Key learning: **Gemini 3+ models use `thinkingLevel`, not `thinkingBudget`** ([thinking docs](https://ai.google.dev/gemini-api/docs/thinking)) — the budget knob is only backwards-compat there and performs poorly. The config is therefore model-aware.

## Changes

### Server — Gemini config (`src/lib/gemini.ts` + both receipt routes)
- **`receiptScanConfig(model)`** picks the right thinking knob per model generation:
  - Gemini 1.x/2.x → `thinkingBudget` via **`GEMINI_THINKING_BUDGET`** (`0` off/default, `-1` dynamic, `128`–`24576` fixed)
  - Gemini 3+ → `thinkingLevel` via **`GEMINI_THINKING_LEVEL`** (`minimal` default | `low` | `medium` | `high`)
- **`GEMINI_FALLBACK_MODEL`** (default `gemini-2.5-flash`, `""` disables): when the primary model exhausts its overload retries, retry once on the fallback — with thinking config rebuilt for *that* model's generation
- **`GEMINI_TIMEOUT_MS`** (default `30000`, `0` disables): overloaded attempts can hang 40–70s before 503ing; aborting early lets retries/fallback kick in sooner. Timeouts are treated as retryable and map to the same 503 "service busy" response
- `responseMimeType: "application/json"` — guaranteed fence-free JSON ([structured output docs](https://ai.google.dev/gemini-api/docs/structured-output)); `stripCodeFences` kept as harmless safety

### Client — upload pipeline (`src/components/app-shell.tsx`, `src/lib/utils.ts`)
- **Pipelined multi-scan**: each file uploads as soon as *its own* compression finishes (previously a `Promise.all` barrier waited for all compressions)
- **HEIC compression on Safari 17+** (OS codec): ~2 MB HEIC → ~300 KB JPEG before upload; Chrome/Firefox gracefully fall back to uploading the original

### Docs
- All four Gemini env vars documented in `.env.example` and `AGENTS.md`

## Test plan

- [x] `pnpm lint` + `pnpm type-check` pass
- [x] Live verify on `gemini-3.5-flash`: config resolves to `thinkingLevel: MINIMAL` + 30s timeout; scan completed in 26.8s **during an active overload wave** (vs 125s hard failure before)
- [x] Live verify on `gemini-2.5-flash`: config resolves to `thinkingBudget: 0`; 3.4s, correct extraction
- [x] Env overrides verified for budget (`-1`/`1024`/unset) and level mapping
- [x] Manual: scan via the app on local dev with `GEMINI_MODEL=gemini-3.5-flash` → `POST /api/receipts/scan 200 in 8.8s` (vs 125s hard failure before this PR); end-to-end retry → fallback chain also exercised during overload waves (504 surfaced one more retryable status, fixed in `a35e72f`)
- [ ] Manual (Safari/iPhone): upload HEIC from Files app — not yet verified; falls back to uploading the original on decode failure, same as pre-PR behavior

## Deploy note

Set in Coolify env as needed (container restart required):
- `GEMINI_MODEL=gemini-3.5-flash` → scans run with `thinkingLevel: minimal` automatically
- To re-enable thinking: `GEMINI_THINKING_LEVEL=medium` (3+) or `GEMINI_THINKING_BUDGET=-1` (2.x) — and consider raising `GEMINI_TIMEOUT_MS`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core receipt OCR behavior and error handling (timeouts, fallback model, 503 mapping); misconfigured env vars could affect scan success or latency, but no auth or data-model changes.
> 
> **Overview**
> Speeds up receipt scanning and improves resilience when Gemini is overloaded or slow.
> 
> **Server (`gemini.ts` + scan/breakdown routes):** Receipt calls now use `receiptScanConfig()` — JSON response mode, model-aware thinking (**`thinkingBudget`** for Gemini 2.x, **`thinkingLevel`** for 3+), and optional per-attempt **`GEMINI_TIMEOUT_MS`**. Retries cover more transient statuses (500/504) and client timeouts; after primary retries fail, **`GEMINI_FALLBACK_MODEL`** is tried once with thinking config rebuilt for that model. Routes map **`isGeminiUnavailable`** (overload + timeout) to the same 503 “service busy” response.
> 
> **Client:** Multi-receipt upload **pipelines** compression and scan (each file posts when its own compress finishes; concurrency raised to 3). **`compressImage`** attempts HEIC on all browsers and falls back to the original file on decode failure (Safari can JPEG-compress HEIC).
> 
> **Docs:** `.env.example`, `README.md`, and `AGENTS.md` document the four new Gemini tuning env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de8988631c038ca8f42444964a7e7962210694ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

