### PR TITLE
fix(gemini): restore thinking by default for receipt scan quality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,16 +12,18 @@ GEMINI_MODEL="gemini-2.5-flash"
 # Fallback model tried once when GEMINI_MODEL stays overloaded (503) after retries.
 # Set to "" to disable fallback.
 GEMINI_FALLBACK_MODEL="gemini-2.5-flash"
-# Thinking for receipt scans — the right knob depends on the model generation:
-# Gemini 2.x (thinkingBudget): 0 = off (fastest, recommended for OCR),
-#   -1 = dynamic thinking, 128-24576 = fixed token budget
-GEMINI_THINKING_BUDGET="0"
-# Gemini 3+ (thinkingLevel): minimal (fastest, recommended for OCR) | low | medium | high
-GEMINI_THINKING_LEVEL="minimal"
+# Thinking for receipt scans — the right knob depends on the model generation.
+# Defaults favor extraction quality; switch to "speed mode" (budget 0 / level
+# minimal) for ~3x faster scans at the cost of reasoning on tricky receipts.
+# Gemini 2.x (thinkingBudget): -1 = dynamic thinking (default, best quality),
+#   0 = off (fastest), 128-24576 = fixed token budget
+GEMINI_THINKING_BUDGET="-1"
+# Gemini 3+ (thinkingLevel): minimal (fastest) | low | medium (default, best quality) | high
+GEMINI_THINKING_LEVEL="medium"
 # Per-attempt timeout in ms — overloaded attempts can hang 40-70s before failing;
 # aborting early lets retries/fallback kick in sooner. 0 disables the timeout.
-# Raise this if you enable deeper thinking (dynamic budget or medium/high level).
-GEMINI_TIMEOUT_MS="30000"
+# Default is generous for thinking-enabled scans; lower it (e.g. 30000) in speed mode.
+GEMINI_TIMEOUT_MS="60000"
 
 # Cron job authentication — shared with the GitHub Actions workflow that triggers
 # /api/cron/bill-reminders daily on production. Set the same value in the deploy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,9 @@ src/
 - `GEMINI_API_KEY` — Google Gemini AI for receipt scanning
 - `GEMINI_MODEL` — Optional; Gemini model for receipt scanning (defaults to `gemini-2.5-flash`)
 - `GEMINI_FALLBACK_MODEL` — Optional; model retried once when the primary stays overloaded (503) after retries (defaults to `gemini-2.5-flash`; `""` disables fallback)
-- `GEMINI_THINKING_BUDGET` — Optional; thinking budget for **Gemini 2.x** models. `0` = off (fastest, default, recommended for OCR), `-1` = dynamic thinking, `128`-`24576` = fixed token budget
-- `GEMINI_THINKING_LEVEL` — Optional; thinking level for **Gemini 3+** models (they use `thinkingLevel`, not `thinkingBudget`): `minimal` (fastest, default, recommended for OCR) | `low` | `medium` | `high`
-- `GEMINI_TIMEOUT_MS` — Optional; per-attempt request timeout in ms (default `30000`, `0` disables). Timed-out attempts are retried like 503s. Raise it when enabling deeper thinking
+- `GEMINI_THINKING_BUDGET` — Optional; thinking budget for **Gemini 2.x** models. `-1` = dynamic thinking (default, best quality), `0` = off (speed mode), `128`-`24576` = fixed token budget
+- `GEMINI_THINKING_LEVEL` — Optional; thinking level for **Gemini 3+** models (they use `thinkingLevel`, not `thinkingBudget`): `minimal` (speed mode) | `low` | `medium` (default, best quality) | `high`
+- `GEMINI_TIMEOUT_MS` — Optional; per-attempt request timeout in ms (default `60000`, `0` disables). Timed-out attempts are retried like 503s. Lower it (e.g. `30000`) when running speed mode
 - `RESEND_API_KEY` — Email sending (verification + password reset)
 - `EMAIL_FROM` — Sender address (optional; defaults to `Budget Tracker <noreply@resend.dev>` if unset). Use a verified Resend domain in production, e.g. `Budget Tracker <noreply@yourdomain.com>`.
 - `AUTH_URL` — Optional; used in preview/staging deployments

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ GEMINI_MODEL="gemini-2.5-flash"
 
 # Gemini tuning (all optional — these are the defaults used when unset)
 GEMINI_FALLBACK_MODEL="gemini-2.5-flash"   # "" disables fallback
-GEMINI_THINKING_LEVEL="minimal"            # used by Gemini 3+ models
-GEMINI_THINKING_BUDGET="0"                 # used by Gemini 2.x models
-GEMINI_TIMEOUT_MS="30000"                  # per-attempt timeout; 0 disables
+GEMINI_THINKING_LEVEL="medium"             # used by Gemini 3+ models
+GEMINI_THINKING_BUDGET="-1"                # used by Gemini 2.x models
+GEMINI_TIMEOUT_MS="60000"                  # per-attempt timeout; 0 disables
 ```
 
 > **Note:** Generate a secure `NEXTAUTH_SECRET` for production with `openssl rand -base64 32`
@@ -109,14 +109,14 @@ GEMINI_TIMEOUT_MS="30000"                  # per-attempt timeout; 0 disables
 
 #### Gemini tuning options
 
-All four are optional — when unset, the defaults shown above apply. The right thinking knob is picked automatically from the model generation.
+All four are optional — when unset, the defaults shown above apply. The right thinking knob is picked automatically from the model generation. Defaults favor **extraction quality** (thinking enabled); switch to **speed mode** (`minimal` / `0`) for ~3x faster scans at the cost of reasoning on tricky receipts.
 
 | Variable | Possible values | Notes |
 |---|---|---|
 | `GEMINI_FALLBACK_MODEL` | any Gemini model id, or `""` | Tried once when `GEMINI_MODEL` stays overloaded (503/504) after retries. `""` disables fallback. Fast alternative: `gemini-2.5-flash-lite` |
-| `GEMINI_THINKING_LEVEL` | `minimal` \| `low` \| `medium` \| `high` | **Gemini 3+ models only** (e.g. `gemini-3.5-flash`). `minimal` is fastest and recommended for OCR; `medium` is the model's own default |
-| `GEMINI_THINKING_BUDGET` | `0` \| `-1` \| `128`–`24576` | **Gemini 2.x models only** (e.g. `gemini-2.5-flash`). `0` = thinking off (fastest), `-1` = dynamic (model decides), number = fixed token budget. Valid range varies per model |
-| `GEMINI_TIMEOUT_MS` | milliseconds, or `0` | Aborts hung attempts so retry/fallback kicks in sooner; timed-out attempts are retried like 503s. `0` disables. Raise it (e.g. `60000`) if you enable deeper thinking |
+| `GEMINI_THINKING_LEVEL` | `minimal` \| `low` \| `medium` \| `high` | **Gemini 3+ models only** (e.g. `gemini-3.5-flash`). `medium` (default) = model's native reasoning; `minimal` = speed mode |
+| `GEMINI_THINKING_BUDGET` | `-1` \| `0` \| `128`–`24576` | **Gemini 2.x models only** (e.g. `gemini-2.5-flash`). `-1` (default) = dynamic thinking, `0` = speed mode, number = fixed token budget. Valid range varies per model |
+| `GEMINI_TIMEOUT_MS` | milliseconds, or `0` | Aborts hung attempts so retry/fallback kicks in sooner; timed-out attempts are retried like 503s. `0` disables. Default `60000` suits thinking-enabled scans; `30000` suits speed mode |
 
 ### 4. Create the database and run migrations
 

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -16,15 +16,17 @@ export const GEMINI_MODEL = process.env.GEMINI_MODEL ?? "gemini-2.5-flash";
 export const GEMINI_FALLBACK_MODEL =
   process.env.GEMINI_FALLBACK_MODEL ?? "gemini-2.5-flash";
 
-/** Thinking budget for Gemini 2.x models — 0 disables thinking (fastest, recommended for OCR),
- *  -1 enables dynamic thinking (model decides), 128-24576 sets a fixed token budget.
- *  Configured via GEMINI_THINKING_BUDGET; defaults to 0. */
+/** Thinking budget for Gemini 2.x models — -1 enables dynamic thinking (model decides,
+ *  best extraction quality), 0 disables thinking (fastest "speed mode"),
+ *  128-24576 sets a fixed token budget.
+ *  Configured via GEMINI_THINKING_BUDGET; defaults to -1. */
 const parsedThinkingBudget = Number.parseInt(process.env.GEMINI_THINKING_BUDGET ?? "", 10);
-export const GEMINI_THINKING_BUDGET = Number.isNaN(parsedThinkingBudget) ? 0 : parsedThinkingBudget;
+export const GEMINI_THINKING_BUDGET = Number.isNaN(parsedThinkingBudget) ? -1 : parsedThinkingBudget;
 
 /** Thinking level for Gemini 3+ models (they use thinkingLevel, not thinkingBudget) —
- *  "minimal" is fastest (recommended for OCR); "medium" is the model default for 3.5 Flash.
- *  Configured via GEMINI_THINKING_LEVEL; defaults to minimal. */
+ *  "medium" is the model default for 3.5 Flash (best extraction quality);
+ *  "minimal" is the fastest "speed mode".
+ *  Configured via GEMINI_THINKING_LEVEL; defaults to medium. */
 const THINKING_LEVELS: Record<string, ThinkingLevel> = {
   minimal: ThinkingLevel.MINIMAL,
   low: ThinkingLevel.LOW,
@@ -32,15 +34,15 @@ const THINKING_LEVELS: Record<string, ThinkingLevel> = {
   high: ThinkingLevel.HIGH,
 };
 export const GEMINI_THINKING_LEVEL =
-  THINKING_LEVELS[(process.env.GEMINI_THINKING_LEVEL ?? "minimal").toLowerCase()] ??
-  ThinkingLevel.MINIMAL;
+  THINKING_LEVELS[(process.env.GEMINI_THINKING_LEVEL ?? "medium").toLowerCase()] ??
+  ThinkingLevel.MEDIUM;
 
 /** Per-attempt request timeout — overloaded Gemini attempts can hang 40-70s before
  *  failing; aborting early lets retries/fallback kick in sooner.
- *  Configured via GEMINI_TIMEOUT_MS; defaults to 30s. Raise it if you enable
- *  deeper thinking (dynamic budget or medium/high level). */
+ *  Configured via GEMINI_TIMEOUT_MS; defaults to 60s, generous enough for
+ *  thinking-enabled scans. Lower it (e.g. 30000) when running in speed mode. */
 const parsedTimeout = Number.parseInt(process.env.GEMINI_TIMEOUT_MS ?? "", 10);
-export const GEMINI_TIMEOUT_MS = Number.isNaN(parsedTimeout) ? 30_000 : parsedTimeout;
+export const GEMINI_TIMEOUT_MS = Number.isNaN(parsedTimeout) ? 60_000 : parsedTimeout;
 
 /** Pick the right thinking knob per model generation:
  *  Gemini 1.x/2.x use thinkingBudget; Gemini 3+ use thinkingLevel


### PR DESCRIPTION
## Summary

Fixes #81

PR #78 traded extraction intelligence for speed by defaulting Gemini thinking **off**. This restores **quality-first defaults** — the model reasons over receipts again (ambiguous dates, line-item grouping, category assignment) — while keeping speed mode one env flip away.

## Audit: which #77/#78 changes nerfed scanning

| Change | Quality impact | Resolution |
|---|---|---|
| `thinkingLevel: minimal` (Gemini 3+) | **The regression** — skipped the model's native reasoning | ✅ Default → `medium` |
| `thinkingBudget: 0` (Gemini 2.x) | Same for 2.x | ✅ Default → `-1` (dynamic) |
| `GEMINI_TIMEOUT_MS=30000` | Would abort legitimate thinking-enabled attempts (20–30s+) | ✅ Default → `60000` |
| Fallback to `gemini-2.5-flash` | Overload answers come from older model | Kept (availability); it now thinks dynamically too |
| `responseMimeType: "application/json"` | None — output format only | Kept |
| Safari HEIC compressed to 1500px | Niche path; every other format was already 1500px pre-#78 | Kept for consistency |
| Pipelined uploads, retries, error toasts | None | Kept |

## Changes

- `src/lib/gemini.ts` — default thinking knobs flipped to quality (`medium` / `-1`), timeout default 60s
- `.env.example`, `README.md`, `AGENTS.md` — defaults documented as quality-first; "speed mode" (`GEMINI_THINKING_LEVEL=minimal` / `GEMINI_THINKING_BUDGET=0`, `GEMINI_TIMEOUT_MS=30000`) documented as the opt-in

## Trade-off (deliberate)

Scans return to ~20–30s on `gemini-3.5-flash` (vs ~8s in speed mode). The retry → fallback → honest-503 resilience from #77/#78 is unchanged.

## Test plan

- [x] `pnpm lint` + `pnpm type-check` pass
- [x] Live verify on `gemini-3.5-flash`: config resolves to `thinkingLevel: MEDIUM` + 60s timeout; response carried **1,199 thought tokens** (vs 0 in speed mode) and correct extraction — run also exercised the overload fallback chain end-to-end (3.5 overloaded → 2.5-flash with dynamic thinking → success)
- [ ] Manual: scan a tricky receipt and compare extraction quality vs speed mode

## Deploy note

No env changes needed — quality defaults apply automatically. To keep production on speed mode instead, set `GEMINI_THINKING_LEVEL=minimal` (3+) or `GEMINI_THINKING_BUDGET=0` (2.x) and optionally `GEMINI_TIMEOUT_MS=30000` in Coolify.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default receipt OCR latency and extraction behavior for any deployment without explicit Gemini env overrides; retry/fallback logic is unchanged.
> 
> **Overview**
> Reverts receipt-scan Gemini defaults from **speed mode** back to **quality-first** thinking, addressing a regression where scans were faster but weaker on ambiguous receipts.
> 
> In `src/lib/gemini.ts`, unset env now resolves to dynamic thinking on Gemini 2.x (`GEMINI_THINKING_BUDGET` **-1** instead of **0**), **`medium`** thinking on Gemini 3+ (instead of **`minimal`**), and a **60s** per-attempt timeout (instead of **30s**) so longer reasoning runs are less likely to abort. `.env.example`, `README.md`, and `AGENTS.md` are updated to document these defaults and how to opt back into speed mode (`0` / `minimal`, optionally `30000` ms timeout).
> 
> Scan and breakdown routes still use `receiptScanConfig()`; only default behavior changes when those variables are not set in production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0185177024752ede2e3f2231db310d3eb545e510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->