### PR TITLE
feat(bills): dismiss reminder banner for the day

### DIFF
--- a/src/components/bills/bill-reminder-banner.tsx
+++ b/src/components/bills/bill-reminder-banner.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { ChevronLeft, ChevronRight, Check, Clock, FastForward, Pencil, ChevronUp, CheckCheck } from "lucide-react";
+import { ChevronLeft, ChevronRight, Check, Clock, FastForward, Pencil, ChevronUp, CheckCheck, X } from "lucide-react";
 import { cn, formatCurrency } from "@/lib/utils";
 import { CategoryIcon } from "@/components/ui/icon-map";
 import { usePrivacy } from "@/components/privacy-provider";
@@ -48,6 +48,8 @@ export function BillReminderBanner({ onPayAndEdit }: BillReminderBannerProps) {
     isActioning,
     payAllProgress,
     setBannerHeight,
+    dismissedForToday,
+    dismissForToday,
   } = useBillReminders();
 
   const [showSnoozeMenu, setShowSnoozeMenu] = useState(false);
@@ -91,7 +93,7 @@ export function BillReminderBanner({ onPayAndEdit }: BillReminderBannerProps) {
   const { hideAmounts } = usePrivacy();
   const { user } = useUser();
 
-  if (pendingReminders.length === 0) return null;
+  if (pendingReminders.length === 0 || dismissedForToday) return null;
 
   const reminder = pendingReminders[currentIndex];
   if (!reminder) return null;
@@ -171,6 +173,16 @@ export function BillReminderBanner({ onPayAndEdit }: BillReminderBannerProps) {
             )}>
               {hideAmounts ? "***" : formatCurrency(bill.amount, user.currency)}
             </span>
+
+            {/* Dismiss for the day */}
+            <button
+              onClick={dismissForToday}
+              aria-label="Dismiss for today"
+              title="Dismiss for today"
+              className="p-1 -mr-1 rounded-lg text-warm-300 hover:text-warm-600 hover:bg-cream-100 transition-colors shrink-0"
+            >
+              <X className="w-4 h-4" />
+            </button>
           </div>
 
           {/* Actions row */}

--- a/src/components/bills/bill-reminder-provider.tsx
+++ b/src/components/bills/bill-reminder-provider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useState, useCallback, useEffect } from "react";
 import { usePendingRemindersQuery, useBillAction } from "@/hooks/use-bills";
 import { useToast } from "@/components/ui/toast";
+import { useUser } from "@/components/user-provider";
 import type { PendingReminder } from "@/types";
 
 interface BillReminderContextValue {
@@ -41,7 +42,8 @@ const BillReminderContext = createContext<BillReminderContextValue>({
 
 export const useBillReminders = () => useContext(BillReminderContext);
 
-const DISMISS_STORAGE_KEY = "bill-reminder-dismissed-date";
+/** Per-user storage key so a dismissal doesn't leak across accounts in a shared browser. */
+const dismissStorageKey = (email: string) => `bill-reminder-dismissed-date:${email}`;
 
 /** Local calendar date as YYYY-MM-DD (used to scope the dismissal to "today"). */
 const getLocalDateKey = () => {
@@ -52,9 +54,21 @@ const getLocalDateKey = () => {
   return `${year}-${month}-${day}`;
 };
 
+/** True when this user dismissed the banner for the current local day. */
+const readDismissed = (email: string) => {
+  if (typeof window === "undefined" || !email) return false;
+  try {
+    return localStorage.getItem(dismissStorageKey(email)) === getLocalDateKey();
+  } catch {
+    return false;
+  }
+};
+
 export function BillReminderProvider({ children }: { children: React.ReactNode }) {
   const { data: pendingReminders = [] } = usePendingRemindersQuery();
   const billAction = useBillAction();
+  const { user } = useUser();
+  const email = user.email;
   const { showToast } = useToast();
   const [currentIndex, setCurrentIndex] = useState(0);
 
@@ -114,25 +128,35 @@ export function BillReminderProvider({ children }: { children: React.ReactNode }
   const [bannerHeight, setBannerHeightRaw] = useState(0);
   const setBannerHeight = useCallback((h: number) => setBannerHeightRaw(h), []);
 
-  // Hide the banner for the rest of the day (client-side only). Rehydrate from
-  // localStorage on mount so a refresh keeps it dismissed until tomorrow.
-  const [dismissedForToday, setDismissedForToday] = useState(false);
+  // Hide the banner for the rest of the day (client-side only). Initialised
+  // lazily from localStorage so a refresh keeps it dismissed without a flash.
+  const [dismissedForToday, setDismissedForToday] = useState(() => readDismissed(email));
+
+  // Re-evaluate when the account changes and when the tab regains focus, so the
+  // banner returns after midnight (or for a different user) without a full reload.
   useEffect(() => {
-    try {
-      setDismissedForToday(localStorage.getItem(DISMISS_STORAGE_KEY) === getLocalDateKey());
-    } catch {
-      // localStorage unavailable (e.g. privacy mode) — banner just stays visible
-    }
-  }, []);
+    const sync = () => setDismissedForToday(readDismissed(email));
+    sync();
+    const onVisible = () => {
+      if (document.visibilityState === "visible") sync();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", sync);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", sync);
+    };
+  }, [email]);
 
   const dismissForToday = useCallback(() => {
+    if (!email) return;
     try {
-      localStorage.setItem(DISMISS_STORAGE_KEY, getLocalDateKey());
+      localStorage.setItem(dismissStorageKey(email), getLocalDateKey());
     } catch {
       // ignore write failures; still hide for this session
     }
     setDismissedForToday(true);
-  }, []);
+  }, [email]);
   const [payAllProgress, setPayAllProgress] = useState<{ current: number; total: number } | null>(null);
 
   const handlePayAll = useCallback(async () => {

--- a/src/components/bills/bill-reminder-provider.tsx
+++ b/src/components/bills/bill-reminder-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState, useCallback } from "react";
+import { createContext, useContext, useState, useCallback, useEffect } from "react";
 import { usePendingRemindersQuery, useBillAction } from "@/hooks/use-bills";
 import { useToast } from "@/components/ui/toast";
 import type { PendingReminder } from "@/types";
@@ -17,6 +17,10 @@ interface BillReminderContextValue {
   payAllProgress: { current: number; total: number } | null;
   bannerHeight: number;
   setBannerHeight: (height: number) => void;
+  /** True when the user dismissed the banner for the current day. */
+  dismissedForToday: boolean;
+  /** Hide the banner until the next calendar day (client-side only — does not change any bill). */
+  dismissForToday: () => void;
 }
 
 const BillReminderContext = createContext<BillReminderContextValue>({
@@ -31,9 +35,22 @@ const BillReminderContext = createContext<BillReminderContextValue>({
   payAllProgress: null,
   bannerHeight: 0,
   setBannerHeight: () => {},
+  dismissedForToday: false,
+  dismissForToday: () => {},
 });
 
 export const useBillReminders = () => useContext(BillReminderContext);
+
+const DISMISS_STORAGE_KEY = "bill-reminder-dismissed-date";
+
+/** Local calendar date as YYYY-MM-DD (used to scope the dismissal to "today"). */
+const getLocalDateKey = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
 
 export function BillReminderProvider({ children }: { children: React.ReactNode }) {
   const { data: pendingReminders = [] } = usePendingRemindersQuery();
@@ -96,6 +113,26 @@ export function BillReminderProvider({ children }: { children: React.ReactNode }
 
   const [bannerHeight, setBannerHeightRaw] = useState(0);
   const setBannerHeight = useCallback((h: number) => setBannerHeightRaw(h), []);
+
+  // Hide the banner for the rest of the day (client-side only). Rehydrate from
+  // localStorage on mount so a refresh keeps it dismissed until tomorrow.
+  const [dismissedForToday, setDismissedForToday] = useState(false);
+  useEffect(() => {
+    try {
+      setDismissedForToday(localStorage.getItem(DISMISS_STORAGE_KEY) === getLocalDateKey());
+    } catch {
+      // localStorage unavailable (e.g. privacy mode) — banner just stays visible
+    }
+  }, []);
+
+  const dismissForToday = useCallback(() => {
+    try {
+      localStorage.setItem(DISMISS_STORAGE_KEY, getLocalDateKey());
+    } catch {
+      // ignore write failures; still hide for this session
+    }
+    setDismissedForToday(true);
+  }, []);
   const [payAllProgress, setPayAllProgress] = useState<{ current: number; total: number } | null>(null);
 
   const handlePayAll = useCallback(async () => {
@@ -158,6 +195,8 @@ export function BillReminderProvider({ children }: { children: React.ReactNode }
         payAllProgress,
         bannerHeight,
         setBannerHeight,
+        dismissedForToday,
+        dismissForToday,
       }}
     >
       {children}

--- a/src/components/bills/bill-reminder-provider.tsx
+++ b/src/components/bills/bill-reminder-provider.tsx
@@ -143,19 +143,36 @@ export function BillReminderProvider({ children }: { children: React.ReactNode }
   // lazily from localStorage so a refresh keeps it dismissed without a flash.
   const [dismissedForToday, setDismissedForToday] = useState(() => readDismissed(email));
 
-  // Re-evaluate when the account changes and when the tab regains focus, so the
-  // banner returns after midnight (or for a different user) without a full reload.
+  // Re-evaluate when the account changes, when the tab regains focus, and at the
+  // next local midnight — so the banner returns the next day whether the tab was
+  // backgrounded/refocused or left continuously open across the day boundary.
   useEffect(() => {
     const sync = () => setDismissedForToday(computeDismissed());
     sync();
+
     const onVisible = () => {
       if (document.visibilityState === "visible") sync();
     };
     document.addEventListener("visibilitychange", onVisible);
     window.addEventListener("focus", sync);
+
+    // Self-rescheduling timer that fires just after each local midnight.
+    let timer: ReturnType<typeof setTimeout>;
+    const scheduleMidnight = () => {
+      const now = new Date();
+      // 5s past midnight to avoid landing on the previous day due to timer skew
+      const nextMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 5);
+      timer = setTimeout(() => {
+        sync();
+        scheduleMidnight();
+      }, nextMidnight.getTime() - now.getTime());
+    };
+    scheduleMidnight();
+
     return () => {
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("focus", sync);
+      clearTimeout(timer);
     };
   }, [computeDismissed]);
 

--- a/src/components/bills/bill-reminder-provider.tsx
+++ b/src/components/bills/bill-reminder-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState, useCallback, useEffect } from "react";
+import { createContext, useContext, useState, useCallback, useEffect, useRef } from "react";
 import { usePendingRemindersQuery, useBillAction } from "@/hooks/use-bills";
 import { useToast } from "@/components/ui/toast";
 import { useUser } from "@/components/user-provider";
@@ -128,6 +128,17 @@ export function BillReminderProvider({ children }: { children: React.ReactNode }
   const [bannerHeight, setBannerHeightRaw] = useState(0);
   const setBannerHeight = useCallback((h: number) => setBannerHeightRaw(h), []);
 
+  // In-session fallback for when localStorage can't persist (private mode/quota):
+  // remembers the dismissal so a focus/visibility resync doesn't flip it back today.
+  const sessionDismissRef = useRef<{ email: string; date: string } | null>(null);
+
+  // Dismissed if persisted today OR dismissed in-session for this user/day.
+  const computeDismissed = useCallback(() => {
+    if (readDismissed(email)) return true;
+    const s = sessionDismissRef.current;
+    return !!s && s.email === email && s.date === getLocalDateKey();
+  }, [email]);
+
   // Hide the banner for the rest of the day (client-side only). Initialised
   // lazily from localStorage so a refresh keeps it dismissed without a flash.
   const [dismissedForToday, setDismissedForToday] = useState(() => readDismissed(email));
@@ -135,7 +146,7 @@ export function BillReminderProvider({ children }: { children: React.ReactNode }
   // Re-evaluate when the account changes and when the tab regains focus, so the
   // banner returns after midnight (or for a different user) without a full reload.
   useEffect(() => {
-    const sync = () => setDismissedForToday(readDismissed(email));
+    const sync = () => setDismissedForToday(computeDismissed());
     sync();
     const onVisible = () => {
       if (document.visibilityState === "visible") sync();
@@ -146,14 +157,16 @@ export function BillReminderProvider({ children }: { children: React.ReactNode }
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("focus", sync);
     };
-  }, [email]);
+  }, [computeDismissed]);
 
   const dismissForToday = useCallback(() => {
     if (!email) return;
+    // Record the in-session dismissal first so it survives even if the write fails.
+    sessionDismissRef.current = { email, date: getLocalDateKey() };
     try {
       localStorage.setItem(dismissStorageKey(email), getLocalDateKey());
     } catch {
-      // ignore write failures; still hide for this session
+      // persistence unavailable — the in-session ref above keeps it hidden today
     }
     setDismissedForToday(true);
   }, [email]);


### PR DESCRIPTION
## Summary
Adds a close (**X**) button to the floating bill reminder banner so it can be hidden for the rest of the day. It reappears the next day to remind again.

Closes #85

## Behavior
- **X** in the banner header (next to the amount) dismisses it for the current day.
- Purely client-side — does **not** pay, snooze, or skip any bill, so the underlying reminders (and email reminders) are unaffected; the bill still shows in Upcoming Bills.
- Persisted in `localStorage` keyed to today's local date (`bill-reminder-dismissed-date`); rehydrates on load so a refresh keeps it hidden until tomorrow, then it returns automatically.

## Changes
- `bill-reminder-provider.tsx` — `dismissedForToday` state + `dismissForToday()`, backed by localStorage (today's `YYYY-MM-DD`). Wrapped in try/catch so unavailable storage just leaves the banner visible.
- `bill-reminder-banner.tsx` — consumes the new state, returns `null` when dismissed (so `bannerHeight` resets to 0 and the FAB offset corrects), and renders the X button.

## Test plan (verified locally via Playwright)
- [x] Banner shows X; clicking it hides the banner
- [x] After reload, banner stays hidden (localStorage persisted)
- [x] Bill remains in Upcoming Bills (not paid/snoozed/skipped)
- [x] `pnpm lint` + `pnpm type-check` pass

## Notes
- "Today" uses the browser's local calendar date. If a session is left open across midnight, the banner reappears on the next data refresh/navigation rather than instantly at 00:00 — acceptable for this UX.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely client-side UI preference with no API or bill mutation; main caveat is localStorage/session edge cases, not financial or auth logic.
> 
> **Overview**
> Adds a **dismiss for today** control on the floating bill reminder banner so users can hide it without paying, snoozing, or skipping bills.
> 
> The banner header gets an **X** button wired to new `dismissedForToday` / `dismissForToday` state on `BillReminderProvider`. Dismissal is **client-only**: it stores the current local calendar date in `localStorage` under a per-user key, with an in-session fallback when storage is unavailable, and re-syncs on account change, tab focus/visibility, and a timer just after local midnight so the banner can return the next day. When dismissed, the banner unmounts (same as no reminders), which clears measured `bannerHeight` for FAB layout.
> 
> Pending reminders and server-side bill state are unchanged; only the in-app banner visibility is affected for the rest of the day.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 959f873f8df1e5b9dd6f50ea5ecee8a8facc966a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bill reminder banner now includes a dismiss button to hide the banner for the current day. The dismissal preference is automatically saved and remembered per user, preventing the banner from reappearing until the next calendar day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->