### PR TITLE
feat(analytics): sticky period nav when scrolled

### DIFF
--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
-import { motion } from "framer-motion";
+import { useState, useCallback, useMemo, useRef } from "react";
+import { motion, AnimatePresence, useInView } from "framer-motion";
 import {
   Activity,
   AlertTriangle,
@@ -89,6 +89,10 @@ export default function AnalyticsPage() {
     setDateRange((prev) => navigatePeriod(periodType, prev.from, prev.to, direction));
   }, [periodType]);
 
+  // Sticky period bar: appears once the header period nav scrolls out of view
+  const headerNavRef = useRef<HTMLDivElement>(null);
+  const headerNavInView = useInView(headerNavRef);
+
   return (
     <div>
       {/* Page Header + Period Selector */}
@@ -97,16 +101,43 @@ export default function AnalyticsPage() {
           <h1 className="font-serif text-2xl lg:text-3xl text-warm-700">Analytics</h1>
           <p className="text-warm-400 text-sm mt-1">Reports &amp; insights</p>
         </div>
-        <TimeRangePicker
-          periodType={periodType}
-          from={dateRange.from}
-          to={dateRange.to}
-          label={periodLabel}
-          tz={tz}
-          onPeriodSelect={handlePeriodSelect}
-          onNavigate={handleNavigate}
-        />
+        <div ref={headerNavRef}>
+          <TimeRangePicker
+            periodType={periodType}
+            from={dateRange.from}
+            to={dateRange.to}
+            label={periodLabel}
+            tz={tz}
+            onPeriodSelect={handlePeriodSelect}
+            onNavigate={handleNavigate}
+          />
+        </div>
       </div>
+
+      {/* Sticky period bar — appears when the header nav scrolls out of view */}
+      <AnimatePresence>
+        {!headerNavInView && (
+          <motion.div
+            initial={{ y: -16, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: -16, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="fixed top-16 lg:top-0 left-0 right-0 lg:left-64 z-30 bg-cream-100/90 backdrop-blur-md border-b border-cream-300/60"
+          >
+            <div className="max-w-6xl mx-auto px-4 lg:px-8 py-2.5">
+              <TimeRangePicker
+                periodType={periodType}
+                from={dateRange.from}
+                to={dateRange.to}
+                label={periodLabel}
+                tz={tz}
+                onPeriodSelect={handlePeriodSelect}
+                onNavigate={handleNavigate}
+              />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Tab Bar */}
       <div role="tablist" className="grid grid-cols-3 sm:flex gap-1 p-1 bg-cream-100 rounded-xl mb-6 sm:w-fit">

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo, useRef, useEffect, type RefObject } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion, AnimatePresence, useIsomorphicLayoutEffect } from "framer-motion";
 import {
   Activity,
   AlertTriangle,
@@ -51,23 +51,31 @@ const ANALYTICS_TABS = [
 ];
 
 /**
- * Like framer-motion's `useInView`, but (1) assumes in-view until the observer
- * first measures — avoiding a first-paint flash of the sticky bar — and (2) takes
- * a `rootMargin` so a fixed header overlapping the viewport top doesn't keep a
- * covered element counted as "in view".
+ * Tracks whether `ref` is visible below a `topOffset` (px) from the viewport top —
+ * used to know when the in-page period nav has scrolled under the fixed header.
+ *
+ * Measures synchronously before paint so the initial value is correct whether the
+ * page mounts at the top (no sticky-bar flash) or already scrolled (restored scroll
+ * / bfcache — bar shown immediately, no lag), then keeps it updated via an observer.
  */
-function useInViewWithMargin<T extends Element>(ref: RefObject<T | null>, rootMargin: string) {
+function useVisibleBelowOffset<T extends Element>(ref: RefObject<T | null>, topOffset: number) {
   const [inView, setInView] = useState(true);
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const el = ref.current;
-    if (!el || typeof IntersectionObserver === "undefined") return;
+    if (!el) return;
+    const measure = () => {
+      const rect = el.getBoundingClientRect();
+      setInView(rect.bottom > topOffset && rect.top < window.innerHeight);
+    };
+    measure();
+    if (typeof IntersectionObserver === "undefined") return;
     const observer = new IntersectionObserver(
       ([entry]) => setInView(entry.isIntersecting),
-      { rootMargin },
+      { rootMargin: `-${topOffset}px 0px 0px 0px` },
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [ref, rootMargin]);
+  }, [ref, topOffset]);
   return inView;
 }
 
@@ -114,15 +122,15 @@ export default function AnalyticsPage() {
   // Below `lg` the app shell has a fixed 4rem header, so offset the observer by it
   // (the in-page nav is unusable once it slides under that header); no offset on desktop.
   const headerNavRef = useRef<HTMLDivElement>(null);
-  const [navRootMargin, setNavRootMargin] = useState("0px");
+  const [headerTopOffset, setHeaderTopOffset] = useState(0);
   useEffect(() => {
     const mq = window.matchMedia("(min-width: 1024px)");
-    const apply = () => setNavRootMargin(mq.matches ? "0px" : "-64px 0px 0px 0px");
+    const apply = () => setHeaderTopOffset(mq.matches ? 0 : 64);
     apply();
     mq.addEventListener("change", apply);
     return () => mq.removeEventListener("change", apply);
   }, []);
-  const headerNavInView = useInViewWithMargin(headerNavRef, navRootMargin);
+  const headerNavInView = useVisibleBelowOffset(headerNavRef, headerTopOffset);
 
   return (
     <div>
@@ -132,7 +140,9 @@ export default function AnalyticsPage() {
           <h1 className="font-serif text-2xl lg:text-3xl text-warm-700">Analytics</h1>
           <p className="text-warm-400 text-sm mt-1">Reports &amp; insights</p>
         </div>
-        <div ref={headerNavRef}>
+        {/* When the sticky copy is shown, mark this off-screen original inert so
+            keyboard/screen-reader users don't hit duplicate, hidden controls. */}
+        <div ref={headerNavRef} inert={!headerNavInView}>
           <TimeRangePicker
             periodType={periodType}
             from={dateRange.from}

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useCallback, useMemo, useRef } from "react";
-import { motion, AnimatePresence, useInView } from "framer-motion";
+import { useState, useCallback, useMemo, useRef, useEffect, type RefObject } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import {
   Activity,
   AlertTriangle,
@@ -50,6 +50,27 @@ const ANALYTICS_TABS = [
   { id: "health" as const, label: "Financial Health", shortLabel: "Health", icon: Heart },
 ];
 
+/**
+ * Like framer-motion's `useInView`, but (1) assumes in-view until the observer
+ * first measures — avoiding a first-paint flash of the sticky bar — and (2) takes
+ * a `rootMargin` so a fixed header overlapping the viewport top doesn't keep a
+ * covered element counted as "in view".
+ */
+function useInViewWithMargin<T extends Element>(ref: RefObject<T | null>, rootMargin: string) {
+  const [inView, setInView] = useState(true);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setInView(entry.isIntersecting),
+      { rootMargin },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref, rootMargin]);
+  return inView;
+}
+
 export default function AnalyticsPage() {
   const { user } = useUser();
   const { hideAmounts } = usePrivacy();
@@ -89,9 +110,19 @@ export default function AnalyticsPage() {
     setDateRange((prev) => navigatePeriod(periodType, prev.from, prev.to, direction));
   }, [periodType]);
 
-  // Sticky period bar: appears once the header period nav scrolls out of view
+  // Sticky period bar: appears once the header period nav scrolls out of view.
+  // Below `lg` the app shell has a fixed 4rem header, so offset the observer by it
+  // (the in-page nav is unusable once it slides under that header); no offset on desktop.
   const headerNavRef = useRef<HTMLDivElement>(null);
-  const headerNavInView = useInView(headerNavRef);
+  const [navRootMargin, setNavRootMargin] = useState("0px");
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 1024px)");
+    const apply = () => setNavRootMargin(mq.matches ? "0px" : "-64px 0px 0px 0px");
+    apply();
+    mq.addEventListener("change", apply);
+    return () => mq.removeEventListener("change", apply);
+  }, []);
+  const headerNavInView = useInViewWithMargin(headerNavRef, navRootMargin);
 
   return (
     <div>

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -122,7 +122,11 @@ export default function AnalyticsPage() {
   // Below `lg` the app shell has a fixed 4rem header, so offset the observer by it
   // (the in-page nav is unusable once it slides under that header); no offset on desktop.
   const headerNavRef = useRef<HTMLDivElement>(null);
-  const [headerTopOffset, setHeaderTopOffset] = useState(0);
+  // Seed the offset from the current viewport so the first (synchronous) measure
+  // already uses the right value on mobile, before the resize listener runs.
+  const [headerTopOffset, setHeaderTopOffset] = useState(() =>
+    typeof window !== "undefined" && !window.matchMedia("(min-width: 1024px)").matches ? 64 : 0,
+  );
   useEffect(() => {
     const mq = window.matchMedia("(min-width: 1024px)");
     const apply = () => setHeaderTopOffset(mq.matches ? 0 : 64);
@@ -132,6 +136,14 @@ export default function AnalyticsPage() {
   }, []);
   const headerNavInView = useVisibleBelowOffset(headerNavRef, headerTopOffset);
 
+  // The sticky copy stays mounted through its exit animation, so track its real
+  // presence and keep the original inert until it's fully gone — otherwise both
+  // pickers are briefly interactive while scrolling back up.
+  const [stickyMounted, setStickyMounted] = useState(false);
+  useEffect(() => {
+    if (!headerNavInView) setStickyMounted(true);
+  }, [headerNavInView]);
+
   return (
     <div>
       {/* Page Header + Period Selector */}
@@ -140,9 +152,9 @@ export default function AnalyticsPage() {
           <h1 className="font-serif text-2xl lg:text-3xl text-warm-700">Analytics</h1>
           <p className="text-warm-400 text-sm mt-1">Reports &amp; insights</p>
         </div>
-        {/* When the sticky copy is shown, mark this off-screen original inert so
-            keyboard/screen-reader users don't hit duplicate, hidden controls. */}
-        <div ref={headerNavRef} inert={!headerNavInView}>
+        {/* Inert while the sticky copy is mounted (incl. its exit), so keyboard /
+            screen-reader users never hit two interactive period pickers. */}
+        <div ref={headerNavRef} inert={stickyMounted}>
           <TimeRangePicker
             periodType={periodType}
             from={dateRange.from}
@@ -156,7 +168,7 @@ export default function AnalyticsPage() {
       </div>
 
       {/* Sticky period bar — appears when the header nav scrolls out of view */}
-      <AnimatePresence>
+      <AnimatePresence onExitComplete={() => setStickyMounted(false)}>
         {!headerNavInView && (
           <motion.div
             initial={{ y: -16, opacity: 0 }}


### PR DESCRIPTION
## Summary
On the long Analytics page, the period navigation (`< June 2026 >`) only lived in the header, so changing month/period meant scrolling all the way back to the top. This adds a **sticky period bar** that appears at the top of the viewport once the header nav scrolls out of view.

Closes #87

## Behavior
- At the top: only the header nav (unchanged).
- Scrolled past the header: a fixed bar slides in at the top with **full parity** — `<`/`>` step the period **and** tapping the label opens the same dropdown (months/weeks/years/custom + presets).
- Scroll back up: the bar slides out.

## Implementation
- Single file: `src/app/(app)/analytics/page.tsx`. No change to `TimeRangePicker` — it's reused as-is with the already-lifted props/handlers.
- Visibility detected with framer-motion's `useInView` on the header nav wrapper (no new dependency).
- Positioning verified against `app-shell.tsx`: `top-16` clears the fixed mobile header, `lg:top-0` + `lg:left-64` clears the desktop sidebar; `z-30` above content/bill-banner; translucent `bg-cream-100/90` backdrop. The picker's own dropdown (`z-50`) still renders above content.

## Test plan (verified via Playwright)
- [x] Mobile (390px) + desktop (1280px): bar absent at top, appears when scrolled
- [x] Prev/next changes the month without jumping scroll; page data updates
- [x] Label opens the full dropdown above content (not clipped); selecting a month updates the page
- [x] Bar clears the mobile header and desktop sidebar
- [x] `pnpm lint` + `pnpm type-check` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change on the Analytics page with no API or auth impact; main risk is edge-case scroll/resize behavior and duplicate a11y controls, which the hook and inert handling address.
> 
> **Overview**
> Adds a **fixed sticky period bar** on the Analytics page so users can change the time range without scrolling back to the header. The bar reuses the existing `TimeRangePicker` with the same handlers and animates in/out with `AnimatePresence` when the header control leaves the viewport.
> 
> Visibility is driven by a new **`useVisibleBelowOffset`** hook: a layout-time measure plus `IntersectionObserver` with a top `rootMargin` so mobile treats the nav as “gone” once it sits under the **4rem** fixed app header (`lg` uses **0** offset). **`stickyMounted`** and **`inert`** on the header wrapper keep only one picker focusable while the sticky copy is mounted through its exit animation.
> 
> Positioning uses **`top-16` / `lg:top-0`** and **`lg:left-64`** to align with the app shell’s mobile header and desktop sidebar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31bdce0ffe5f19d0697f45143491f39c8fcf8664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics page now includes a sticky period selector that remains visible while scrolling through data, allowing quick access to time range controls without returning to the top of the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->