### PR TITLE
feat(analytics): hero above tabs + combined sticky period/tabs bar

### DIFF
--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -36,7 +36,7 @@ import { LabelBreakdownChart } from "@/components/analytics/label-breakdown-char
 import { SpendingHeatmap } from "@/components/analytics/spending-heatmap";
 import { TopTransactions } from "@/components/analytics/top-transactions";
 import { AnalyticsHero } from "@/components/analytics/analytics-hero";
-import { AnalyticsSkeleton } from "@/components/analytics/analytics-skeleton";
+import { AnalyticsHeroSkeleton, AnalyticsContentSkeleton } from "@/components/analytics/analytics-skeleton";
 import { RecordsStatistics } from "@/components/analytics/records-statistics";
 import { FinancialHealthScore } from "@/components/analytics/financial-health-score";
 import { stagger, fadeUp } from "@/components/analytics/motion-variants";
@@ -192,6 +192,28 @@ export default function AnalyticsPage() {
         )}
       </AnimatePresence>
 
+      {/* Hero overview — above the tabs: it's tab-independent and changes only
+          with the selected period, so it stays put while the tabs switch below. */}
+      {isLoading ? (
+        <div className="mb-6">
+          <AnalyticsHeroSkeleton />
+        </div>
+      ) : isError || !data ? null : (
+        <motion.div variants={stagger} initial="hidden" animate="show" className="mb-6">
+          <motion.div variants={fadeUp}>
+            <AnalyticsHero
+              summary={data.summary}
+              previousSummary={data.previousSummary}
+              cashFlow={data.cashFlow}
+              periodLabel={data.periodLabel}
+              previousPeriodLabel={data.previousPeriodLabel}
+              currency={currency}
+              hideAmounts={hideAmounts}
+            />
+          </motion.div>
+        </motion.div>
+      )}
+
       {/* Tab Bar */}
       <div role="tablist" className="grid grid-cols-3 sm:flex gap-1 p-1 bg-cream-100 rounded-xl mb-6 sm:w-fit">
         {ANALYTICS_TABS.map((tab) => (
@@ -222,7 +244,7 @@ export default function AnalyticsPage() {
       </div>
 
       {isLoading ? (
-        <AnalyticsSkeleton />
+        <AnalyticsContentSkeleton />
       ) : isError || !data ? (
         <div className="card p-8 flex flex-col items-center gap-3 text-center">
           <div className="w-12 h-12 rounded-xl bg-red-50 flex items-center justify-center">
@@ -241,21 +263,6 @@ export default function AnalyticsPage() {
         </div>
       ) : (
         <>
-          {/* Hero overview (always visible) */}
-          <motion.div variants={stagger} initial="hidden" animate="show">
-            <motion.div variants={fadeUp}>
-              <AnalyticsHero
-                summary={data.summary}
-                previousSummary={data.previousSummary}
-                cashFlow={data.cashFlow}
-                periodLabel={data.periodLabel}
-                previousPeriodLabel={data.previousPeriodLabel}
-                currency={currency}
-                hideAmounts={hideAmounts}
-              />
-            </motion.div>
-          </motion.div>
-
           {/* Reports Tab */}
           {activeTab === "reports" && (
             <motion.div
@@ -263,7 +270,7 @@ export default function AnalyticsPage() {
               variants={stagger}
               initial="hidden"
               animate="show"
-              className="space-y-4 mt-4"
+              className="space-y-4"
             >
               {/* Cash Flow */}
               <motion.div variants={fadeUp} className="card p-5">
@@ -331,14 +338,14 @@ export default function AnalyticsPage() {
 
           {/* Records & Statistics Tab */}
           {activeTab === "statistics" && (
-            <motion.div key="statistics" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} className="mt-4">
+            <motion.div key="statistics" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}>
               <RecordsStatistics statistics={data.statistics} currency={currency} hideAmounts={hideAmounts} />
             </motion.div>
           )}
 
           {/* Financial Health Tab */}
           {activeTab === "health" && (
-            <motion.div key="health" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} className="mt-4">
+            <motion.div key="health" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}>
               <FinancialHealthScore healthScore={data.healthScore} />
             </motion.div>
           )}

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -224,7 +224,32 @@ export default function AnalyticsPage() {
   // tab collapses the page and clamps the scroll, bringing the in-page controls back.
   const recomputeToken = `${activeTab}:${isLoading}`;
   const periodNavInView = useVisibleBelowOffset(periodNavRef, topOffset, recomputeToken);
-  const tabBarInView = useVisibleBelowOffset(tabBarRef, topOffset, recomputeToken);
+
+  // Distance from the sticky bar's top to the bottom of the pinned period row
+  // (its offsetTop within the fixed bar + its height, so the bar's own padding is
+  // included). The tab sentinel uses this so the in-page tab bar counts as "out of
+  // view" the moment it slides under that fixed row — otherwise there's a band where
+  // the period row covers the in-page tabs but the sticky tabs row hasn't appeared.
+  const periodRowRef = useRef<HTMLDivElement>(null);
+  const [periodRowExtent, setPeriodRowExtent] = useState(0);
+  useIsomorphicLayoutEffect(() => {
+    const el = periodRowRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    // Keep the last non-zero value: the row is display:none (extent 0) while hidden,
+    // so caching avoids a 1-frame wrong offset when it re-appears.
+    const measure = () => {
+      const extent = el.offsetTop + el.offsetHeight;
+      if (el.offsetHeight > 0) setPeriodRowExtent(extent);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  // When the period row is pinned, the tab bar must clear below it; otherwise just the header.
+  const tabTopOffset = topOffset + (periodNavInView ? 0 : periodRowExtent);
+  const tabBarInView = useVisibleBelowOffset(tabBarRef, tabTopOffset, recomputeToken);
+
   // Each in-page control is inert exactly when its sticky row is shown; derived
   // directly from visibility so it can never get stuck. The bar itself is active
   // whenever either row is shown.
@@ -270,7 +295,7 @@ export default function AnalyticsPage() {
           {/* Each row is always mounted and shown via `hidden` (no mount churn) so a
               momentarily-stale measure can't cause a flicker; the matching in-page
               control is hidden whenever its sticky row is visible. */}
-          <div className={cn(periodNavInView && "hidden")}>
+          <div ref={periodRowRef} className={cn(periodNavInView && "hidden")}>
             <TimeRangePicker
               periodType={periodType}
               from={dateRange.from}

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -200,11 +200,13 @@ export default function AnalyticsPage() {
     setDateRange((prev) => navigatePeriod(periodType, prev.from, prev.to, direction));
   }, [periodType]);
 
-  // Sticky controls bar: a combined period-nav + tabs bar that appears once the
-  // in-page tab bar (the lower of the two controls) scrolls out of view, so both
-  // controls stay reachable while reading the long content below.
-  // Below `lg` the app shell has a fixed 4rem header, so offset the observer by it
+  // Sticky controls bar: a combined period-nav + tabs bar whose two rows are revealed
+  // independently — each row appears as soon as its in-page counterpart scrolls out of
+  // view, so the period picker is reachable the moment the header nav leaves (not only
+  // once the tabs leave) while never duplicating a control that's still on screen.
+  // Below `lg` the app shell has a fixed 4rem header, so offset the observers by it
   // (the controls are unusable once they slide under that header); no offset on desktop.
+  const periodNavRef = useRef<HTMLDivElement>(null);
   const tabBarRef = useRef<HTMLDivElement>(null);
   // Seed the offset from the current viewport so the first (synchronous) measure
   // already uses the right value on mobile, before the resize listener runs.
@@ -220,11 +222,13 @@ export default function AnalyticsPage() {
   }, []);
   // Re-measure when the active tab or load state changes — switching to a shorter
   // tab collapses the page and clamps the scroll, bringing the in-page controls back.
-  const controlsInView = useVisibleBelowOffset(tabBarRef, topOffset, `${activeTab}:${isLoading}`);
-  // The sticky copy is shown exactly when the in-page controls are out of view, so
-  // the in-page copies are inert then — derived directly so it can never get stuck
-  // (a separate "mounted until exit" flag could deadlock the tabs if its reset missed).
-  const controlsInert = !controlsInView;
+  const recomputeToken = `${activeTab}:${isLoading}`;
+  const periodNavInView = useVisibleBelowOffset(periodNavRef, topOffset, recomputeToken);
+  const tabBarInView = useVisibleBelowOffset(tabBarRef, topOffset, recomputeToken);
+  // Each in-page control is inert exactly when its sticky row is shown; derived
+  // directly from visibility so it can never get stuck. The bar itself is active
+  // whenever either row is shown.
+  const stickyActive = !periodNavInView || !tabBarInView;
 
   return (
     <div>
@@ -234,9 +238,9 @@ export default function AnalyticsPage() {
           <h1 className="font-serif text-2xl lg:text-3xl text-warm-700">Analytics</h1>
           <p className="text-warm-400 text-sm mt-1">Reports &amp; insights</p>
         </div>
-        {/* Inert while the sticky copy is shown, so keyboard / screen-reader users
+        {/* Inert once its sticky row is shown, so keyboard / screen-reader users
             never hit two interactive period pickers. */}
-        <div inert={controlsInert}>
+        <div ref={periodNavRef} inert={!periodNavInView}>
           <TimeRangePicker
             periodType={periodType}
             from={dateRange.from}
@@ -249,29 +253,35 @@ export default function AnalyticsPage() {
         </div>
       </div>
 
-      {/* Sticky controls bar — combined period nav + tabs, revealed once the in-page
-          tab bar scrolls out of view so both stay reachable while scrolling content.
-          Always mounted and toggled with CSS + inert (no mount/unmount race): when the
-          in-page controls are visible this is hidden, inert, and click-through. */}
+      {/* Sticky controls bar — combined period nav + tabs. Each row is shown only when
+          its in-page counterpart has scrolled out of view, so a control is pinned the
+          moment it leaves (and never duplicated while still on screen). Always mounted
+          and toggled with CSS + inert (no mount/unmount race) so it can't leave a hidden
+          click-catching ghost. */}
       <div
-        inert={controlsInView}
-        aria-hidden={controlsInView}
+        inert={!stickyActive}
+        aria-hidden={!stickyActive}
         className={cn(
           "fixed top-16 lg:top-0 left-0 right-0 lg:left-64 z-30 bg-cream-100/90 backdrop-blur-md border-b border-cream-300/60 transition-[opacity,transform] duration-200",
-          controlsInView ? "opacity-0 -translate-y-2 pointer-events-none" : "opacity-100 translate-y-0"
+          stickyActive ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2 pointer-events-none"
         )}
       >
         <div className="max-w-6xl mx-auto px-4 lg:px-8 py-2.5 space-y-2">
-          <TimeRangePicker
-            periodType={periodType}
-            from={dateRange.from}
-            to={dateRange.to}
-            label={periodLabel}
-            tz={tz}
-            onPeriodSelect={handlePeriodSelect}
-            onNavigate={handleNavigate}
-          />
-          <div className="flex justify-center">
+          {/* Each row is always mounted and shown via `hidden` (no mount churn) so a
+              momentarily-stale measure can't cause a flicker; the matching in-page
+              control is hidden whenever its sticky row is visible. */}
+          <div className={cn(periodNavInView && "hidden")}>
+            <TimeRangePicker
+              periodType={periodType}
+              from={dateRange.from}
+              to={dateRange.to}
+              label={periodLabel}
+              tz={tz}
+              onPeriodSelect={handlePeriodSelect}
+              onNavigate={handleNavigate}
+            />
+          </div>
+          <div className={cn("justify-center", tabBarInView ? "hidden" : "flex")}>
             <AnalyticsTabBar
               activeTab={activeTab}
               onSelect={setActiveTab}
@@ -304,8 +314,8 @@ export default function AnalyticsPage() {
         </motion.div>
       )}
 
-      {/* Tab Bar — the sticky-bar sentinel; inert while the sticky copy is shown */}
-      <div ref={tabBarRef} inert={controlsInert} className="mb-6">
+      {/* Tab Bar — sticky-bar sentinel; inert once its sticky row is shown */}
+      <div ref={tabBarRef} inert={!tabBarInView} className="mb-6">
         <AnalyticsTabBar
           activeTab={activeTab}
           onSelect={setActiveTab}

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo, useRef, useEffect, type RefObject } from "react";
-import { motion, AnimatePresence, useIsomorphicLayoutEffect } from "framer-motion";
+import { motion, useIsomorphicLayoutEffect } from "framer-motion";
 import {
   Activity,
   AlertTriangle,
@@ -52,31 +52,113 @@ const ANALYTICS_TABS = [
 
 /**
  * Tracks whether `ref` is visible below a `topOffset` (px) from the viewport top —
- * used to know when the in-page period nav has scrolled under the fixed header.
+ * used to know when the in-page controls have scrolled under the fixed header.
  *
  * Measures synchronously before paint so the initial value is correct whether the
  * page mounts at the top (no sticky-bar flash) or already scrolled (restored scroll
- * / bfcache — bar shown immediately, no lag), then keeps it updated via an observer.
+ * / bfcache — bar shown immediately, no lag). Re-measures on scroll, on resize, and
+ * when the page height changes (ResizeObserver) — always on the next animation frame
+ * so the browser has settled layout/scroll first. This matters when switching to a
+ * shorter tab: the page shrinks and the scroll position clamps without firing a
+ * scroll event, which an IntersectionObserver alone can miss (leaving the bar stuck).
  */
-function useVisibleBelowOffset<T extends Element>(ref: RefObject<T | null>, topOffset: number) {
+function useVisibleBelowOffset<T extends Element>(
+  ref: RefObject<T | null>,
+  topOffset: number,
+  /** Changes to this re-measure on the next frame (e.g. a tab switch that changes
+   *  page height and clamps the scroll without firing a scroll event). */
+  recomputeToken?: unknown,
+) {
   const [inView, setInView] = useState(true);
+
   useIsomorphicLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;
+    let raf = 0;
     const measure = () => {
       const rect = el.getBoundingClientRect();
       setInView(rect.bottom > topOffset && rect.top < window.innerHeight);
     };
+    // Defer to the next frame so scroll-clamping from a height change has applied.
+    const schedule = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(measure);
+    };
+
     measure();
-    if (typeof IntersectionObserver === "undefined") return;
-    const observer = new IntersectionObserver(
-      ([entry]) => setInView(entry.isIntersecting),
-      { rootMargin: `-${topOffset}px 0px 0px 0px` },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
+    window.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("resize", schedule);
+    const ro = typeof ResizeObserver !== "undefined" ? new ResizeObserver(schedule) : null;
+    ro?.observe(document.documentElement);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("scroll", schedule);
+      window.removeEventListener("resize", schedule);
+      ro?.disconnect();
+    };
   }, [ref, topOffset]);
+
+  // Re-measure when content that affects page height changes. The scroll can clamp
+  // without a scroll event, so do it on the next frame once layout has settled.
+  useIsomorphicLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const raf = requestAnimationFrame(() => {
+      const rect = el.getBoundingClientRect();
+      setInView(rect.bottom > topOffset && rect.top < window.innerHeight);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [ref, topOffset, recomputeToken]);
+
   return inView;
+}
+
+/**
+ * Tab switcher. `layoutId` must be unique per rendered instance — the in-page and
+ * sticky copies are mounted at once, and a shared id would make the active pill
+ * animate across the two bars.
+ */
+function AnalyticsTabBar({
+  activeTab,
+  onSelect,
+  layoutId,
+  className,
+}: {
+  activeTab: AnalyticsTab;
+  onSelect: (tab: AnalyticsTab) => void;
+  layoutId: string;
+  className?: string;
+}) {
+  return (
+    <div role="tablist" className={cn("grid grid-cols-3 sm:flex gap-1 p-1 bg-cream-100 rounded-xl", className)}>
+      {ANALYTICS_TABS.map((tab) => (
+        <button
+          key={tab.id}
+          role="tab"
+          aria-selected={activeTab === tab.id}
+          onClick={() => onSelect(tab.id)}
+          className={cn(
+            "relative flex items-center justify-center gap-1.5 px-3 py-2.5 sm:py-1.5 rounded-lg text-sm font-medium transition-colors",
+            activeTab === tab.id ? "text-warm-700" : "text-warm-400 hover:text-warm-500"
+          )}
+        >
+          {activeTab === tab.id && (
+            <motion.span
+              layoutId={layoutId}
+              className="absolute inset-0 bg-white rounded-lg shadow-sm"
+              transition={{ type: "spring", bounce: 0.2, duration: 0.4 }}
+            />
+          )}
+          <tab.icon className="relative w-4 h-4" />
+          <span className="relative">
+            <span className="hidden sm:inline">{tab.label}</span>
+            <span className="sm:hidden">{tab.shortLabel}</span>
+          </span>
+        </button>
+      ))}
+    </div>
+  );
 }
 
 export default function AnalyticsPage() {
@@ -118,31 +200,31 @@ export default function AnalyticsPage() {
     setDateRange((prev) => navigatePeriod(periodType, prev.from, prev.to, direction));
   }, [periodType]);
 
-  // Sticky period bar: appears once the header period nav scrolls out of view.
+  // Sticky controls bar: a combined period-nav + tabs bar that appears once the
+  // in-page tab bar (the lower of the two controls) scrolls out of view, so both
+  // controls stay reachable while reading the long content below.
   // Below `lg` the app shell has a fixed 4rem header, so offset the observer by it
-  // (the in-page nav is unusable once it slides under that header); no offset on desktop.
-  const headerNavRef = useRef<HTMLDivElement>(null);
+  // (the controls are unusable once they slide under that header); no offset on desktop.
+  const tabBarRef = useRef<HTMLDivElement>(null);
   // Seed the offset from the current viewport so the first (synchronous) measure
   // already uses the right value on mobile, before the resize listener runs.
-  const [headerTopOffset, setHeaderTopOffset] = useState(() =>
+  const [topOffset, setTopOffset] = useState(() =>
     typeof window !== "undefined" && !window.matchMedia("(min-width: 1024px)").matches ? 64 : 0,
   );
   useEffect(() => {
     const mq = window.matchMedia("(min-width: 1024px)");
-    const apply = () => setHeaderTopOffset(mq.matches ? 0 : 64);
+    const apply = () => setTopOffset(mq.matches ? 0 : 64);
     apply();
     mq.addEventListener("change", apply);
     return () => mq.removeEventListener("change", apply);
   }, []);
-  const headerNavInView = useVisibleBelowOffset(headerNavRef, headerTopOffset);
-
-  // The sticky copy stays mounted through its exit animation, so track its real
-  // presence and keep the original inert until it's fully gone — otherwise both
-  // pickers are briefly interactive while scrolling back up.
-  const [stickyMounted, setStickyMounted] = useState(false);
-  useEffect(() => {
-    if (!headerNavInView) setStickyMounted(true);
-  }, [headerNavInView]);
+  // Re-measure when the active tab or load state changes — switching to a shorter
+  // tab collapses the page and clamps the scroll, bringing the in-page controls back.
+  const controlsInView = useVisibleBelowOffset(tabBarRef, topOffset, `${activeTab}:${isLoading}`);
+  // The sticky copy is shown exactly when the in-page controls are out of view, so
+  // the in-page copies are inert then — derived directly so it can never get stuck
+  // (a separate "mounted until exit" flag could deadlock the tabs if its reset missed).
+  const controlsInert = !controlsInView;
 
   return (
     <div>
@@ -152,9 +234,9 @@ export default function AnalyticsPage() {
           <h1 className="font-serif text-2xl lg:text-3xl text-warm-700">Analytics</h1>
           <p className="text-warm-400 text-sm mt-1">Reports &amp; insights</p>
         </div>
-        {/* Inert while the sticky copy is mounted (incl. its exit), so keyboard /
-            screen-reader users never hit two interactive period pickers. */}
-        <div ref={headerNavRef} inert={stickyMounted}>
+        {/* Inert while the sticky copy is shown, so keyboard / screen-reader users
+            never hit two interactive period pickers. */}
+        <div inert={controlsInert}>
           <TimeRangePicker
             periodType={periodType}
             from={dateRange.from}
@@ -167,30 +249,38 @@ export default function AnalyticsPage() {
         </div>
       </div>
 
-      {/* Sticky period bar — appears when the header nav scrolls out of view */}
-      <AnimatePresence onExitComplete={() => setStickyMounted(false)}>
-        {!headerNavInView && (
-          <motion.div
-            initial={{ y: -16, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            exit={{ y: -16, opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            className="fixed top-16 lg:top-0 left-0 right-0 lg:left-64 z-30 bg-cream-100/90 backdrop-blur-md border-b border-cream-300/60"
-          >
-            <div className="max-w-6xl mx-auto px-4 lg:px-8 py-2.5">
-              <TimeRangePicker
-                periodType={periodType}
-                from={dateRange.from}
-                to={dateRange.to}
-                label={periodLabel}
-                tz={tz}
-                onPeriodSelect={handlePeriodSelect}
-                onNavigate={handleNavigate}
-              />
-            </div>
-          </motion.div>
+      {/* Sticky controls bar — combined period nav + tabs, revealed once the in-page
+          tab bar scrolls out of view so both stay reachable while scrolling content.
+          Always mounted and toggled with CSS + inert (no mount/unmount race): when the
+          in-page controls are visible this is hidden, inert, and click-through. */}
+      <div
+        inert={controlsInView}
+        aria-hidden={controlsInView}
+        className={cn(
+          "fixed top-16 lg:top-0 left-0 right-0 lg:left-64 z-30 bg-cream-100/90 backdrop-blur-md border-b border-cream-300/60 transition-[opacity,transform] duration-200",
+          controlsInView ? "opacity-0 -translate-y-2 pointer-events-none" : "opacity-100 translate-y-0"
         )}
-      </AnimatePresence>
+      >
+        <div className="max-w-6xl mx-auto px-4 lg:px-8 py-2.5 space-y-2">
+          <TimeRangePicker
+            periodType={periodType}
+            from={dateRange.from}
+            to={dateRange.to}
+            label={periodLabel}
+            tz={tz}
+            onPeriodSelect={handlePeriodSelect}
+            onNavigate={handleNavigate}
+          />
+          <div className="flex justify-center">
+            <AnalyticsTabBar
+              activeTab={activeTab}
+              onSelect={setActiveTab}
+              layoutId="analytics-tab-sticky"
+              className="sm:w-fit"
+            />
+          </div>
+        </div>
+      </div>
 
       {/* Hero overview — above the tabs: it's tab-independent and changes only
           with the selected period, so it stays put while the tabs switch below. */}
@@ -214,33 +304,14 @@ export default function AnalyticsPage() {
         </motion.div>
       )}
 
-      {/* Tab Bar */}
-      <div role="tablist" className="grid grid-cols-3 sm:flex gap-1 p-1 bg-cream-100 rounded-xl mb-6 sm:w-fit">
-        {ANALYTICS_TABS.map((tab) => (
-          <button
-            key={tab.id}
-            role="tab"
-            aria-selected={activeTab === tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={cn(
-              "relative flex items-center justify-center gap-1.5 px-3 py-2.5 sm:py-1.5 rounded-lg text-sm font-medium transition-colors",
-              activeTab === tab.id ? "text-warm-700" : "text-warm-400 hover:text-warm-500"
-            )}
-          >
-            {activeTab === tab.id && (
-              <motion.span
-                layoutId="analytics-tab"
-                className="absolute inset-0 bg-white rounded-lg shadow-sm"
-                transition={{ type: "spring", bounce: 0.2, duration: 0.4 }}
-              />
-            )}
-            <tab.icon className="relative w-4 h-4" />
-            <span className="relative">
-              <span className="hidden sm:inline">{tab.label}</span>
-              <span className="sm:hidden">{tab.shortLabel}</span>
-            </span>
-          </button>
-        ))}
+      {/* Tab Bar — the sticky-bar sentinel; inert while the sticky copy is shown */}
+      <div ref={tabBarRef} inert={controlsInert} className="mb-6">
+        <AnalyticsTabBar
+          activeTab={activeTab}
+          onSelect={setActiveTab}
+          layoutId="analytics-tab"
+          className="sm:w-fit"
+        />
       </div>
 
       {isLoading ? (

--- a/src/components/analytics/analytics-skeleton.tsx
+++ b/src/components/analytics/analytics-skeleton.tsx
@@ -1,32 +1,37 @@
 "use client";
 
-export function AnalyticsSkeleton() {
+/** Skeleton for the hero overview row (rendered above the tabs). */
+export function AnalyticsHeroSkeleton() {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 animate-pulse">
+      <div className="card p-5 lg:p-6 lg:col-span-2 space-y-3">
+        <div className="w-40 h-3 rounded animate-shimmer" />
+        <div className="flex items-center gap-3">
+          <div className="w-44 h-9 rounded animate-shimmer" />
+          <div className="w-16 h-5 rounded-full animate-shimmer" />
+        </div>
+        <div className="h-14 rounded-xl animate-shimmer" />
+      </div>
+      <div className="card p-5 space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-xl animate-shimmer" />
+            <div className="flex-1 space-y-1.5">
+              <div className="w-16 h-2.5 rounded animate-shimmer" />
+              <div className="w-24 h-4 rounded animate-shimmer" />
+            </div>
+            <div className="w-12 h-5 rounded-full animate-shimmer" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Skeleton for the tab content (rendered below the tabs). */
+export function AnalyticsContentSkeleton() {
   return (
     <div className="space-y-4 animate-pulse">
-      {/* Hero row */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        <div className="card p-5 lg:p-6 lg:col-span-2 space-y-3">
-          <div className="w-40 h-3 rounded animate-shimmer" />
-          <div className="flex items-center gap-3">
-            <div className="w-44 h-9 rounded animate-shimmer" />
-            <div className="w-16 h-5 rounded-full animate-shimmer" />
-          </div>
-          <div className="h-14 rounded-xl animate-shimmer" />
-        </div>
-        <div className="card p-5 space-y-4">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-3">
-              <div className="w-9 h-9 rounded-xl animate-shimmer" />
-              <div className="flex-1 space-y-1.5">
-                <div className="w-16 h-2.5 rounded animate-shimmer" />
-                <div className="w-24 h-4 rounded animate-shimmer" />
-              </div>
-              <div className="w-12 h-5 rounded-full animate-shimmer" />
-            </div>
-          ))}
-        </div>
-      </div>
-
       {/* Full-width chart */}
       <div className="card p-5 space-y-3">
         <div className="flex items-center gap-3">
@@ -79,6 +84,16 @@ export function AnalyticsSkeleton() {
           ))}
         </div>
       </div>
+    </div>
+  );
+}
+
+/** Full analytics skeleton (hero + content), kept for convenience. */
+export function AnalyticsSkeleton() {
+  return (
+    <div className="space-y-4">
+      <AnalyticsHeroSkeleton />
+      <AnalyticsContentSkeleton />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Two related Analytics layout improvements:

1. **Hero above the tabs** — the summary (Net Cash Flow / Income / Expenses / Transactions) is tab-independent (changes only with the period), so it now renders above the tab bar as a period-level overview that stays put while the tabs switch the detail views below.

2. **Combined sticky controls bar** — while scrolling the long page, a single sticky top bar keeps BOTH the period nav and the tabs reachable. It's revealed once the in-page tab bar (the lower control) scrolls out of view.

Closes #89 · Refs #87

## Implementation notes
- **Hero**: rendered above `role=tablist`; `AnalyticsSkeleton` split into `AnalyticsHeroSkeleton` + `AnalyticsContentSkeleton` so loading mirrors the loaded layout (no shift).
- **Sticky bar**: always-mounted, toggled via CSS opacity/transform + `inert` + `pointer-events` (not AnimatePresence). Visibility tracked by a scroll/resize/ResizeObserver hook that re-measures on the next frame, plus a recompute keyed to the active tab/load state.
- In-page controls are `inert` exactly when the sticky copy is active (derived from visibility, so it can't get stuck); the tab pill uses a distinct `layoutId` per copy.

## Robustness fixes (from review + manual testing)
- No sticky-bar flash on load; correct when mounted already-scrolled (synchronous pre-paint measure).
- Accounts for the fixed 4rem mobile header (responsive offset).
- **Fixed a deadlock**: switching to a shorter tab (e.g. Financial Health) while scrolled collapsed the page and clamped the scroll *without a scroll event* — the old IntersectionObserver missed it and AnimatePresence left the exited bar at `opacity:0` still intercepting clicks, making the tabs unclickable. The always-mounted + re-measure approach resolves it.

## Verified (Playwright, mobile 390px + desktop 1280px)
- Hero stays above tabs and unchanged across all three tabs.
- Sticky bar: hidden+inert+click-through at top; visible+interactive when scrolled; tabs and period nav both work from it.
- Repro of the reported bug (scroll to bottom → sticky → Financial Health → switch tabs) now works end-to-end.
- `pnpm lint` + `pnpm type-check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved sticky controls behavior and visibility detection in analytics
  * Reorganized loading skeleton states with dedicated hero section loading
  * Enhanced accessibility with improved attribute handling
  * Restructured analytics tab layout for better organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large client-side scroll/sticky and focus (`inert`) logic with two duplicated control surfaces; regressions would affect navigation and clickability, but there is no backend or data-layer impact.
> 
> **Overview**
> Moves the period **AnalyticsHero** summary above the tab bar so it stays visible while switching Reports / Stats / Health, and splits loading into **`AnalyticsHeroSkeleton`** + **`AnalyticsContentSkeleton`** to match that layout.
> 
> Replaces the period-only sticky bar with a **combined fixed controls bar** (period picker + tabs). Each sticky row appears only when its in-page twin scrolls out of view, with separate visibility sentinels, mobile header offset, and a dynamic tab offset when the period row is pinned so controls do not overlap.
> 
> **Sticky behavior refactor:** drops `AnimatePresence` for an always-mounted bar toggled via CSS, `inert`, and `pointer-events-none`; extracts **`AnalyticsTabBar`** with distinct Framer `layoutId`s for in-page vs sticky copies. **`useVisibleBelowOffset`** now uses scroll/resize/`ResizeObserver` + `requestAnimationFrame` and a tab/load **`recomputeToken`** instead of `IntersectionObserver`, fixing stuck hidden overlays when a shorter tab clamps scroll without a scroll event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df137cf1a6f1e34ba492012e95979bc04183e449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->