### PR TITLE
feat(nav): profile menu — mobile bottom sheet + desktop dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,11 @@ yarn-error.log*
 # env files
 .env
 .env*.local
+.env.*
+!.env.example
+
+# local tool artifacts
+.playwright-mcp/
 
 # vercel
 .vercel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable development history for the Budget Tracker app.
 
+## 2026-06-15 — Profile Menu
+
+### Account & Quick-Nav Menu
+- Tapping the profile icon now opens a menu instead of navigating straight to `/profile`
+- **Mobile**: native-style bottom sheet (drag-to-dismiss) built with the `vaul` library
+- **Desktop**: anchored dropdown opening upward from the sidebar profile row (Framer Motion)
+- Items: My Profile, Admin (admins only), Hide/Show amounts toggle, Log out; plus Bills & Categories on mobile only (desktop already lists them in the sidebar)
+- Hide-amounts toggle flips inline via `usePrivacy()` and keeps the menu open for feedback
+- Standalone desktop "Sign Out" button folded into the menu
+- Mobile bottom nav: Dashboard / Transactions / Analytics (+ Scan) + a **Profile** tab that opens the sheet — Bills & Categories moved into the menu (desktop sidebar unchanged)
+- Profile trigger moved out of the top mobile header (now logo/title only) into the bottom nav tab
+- New component: `src/components/profile-menu.tsx`; new dependency: `vaul@1.1.2`
+
 ## 2026-04-07 — Financial Health Score (Analytics Phase 4)
 
 ### Financial Health Tab

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-hook-form": "^7.54.0",
     "recharts": "^2.15.0",
     "resend": "^6.9.3",
+    "vaul": "^1.1.2",
     "zod": "^3.24.0"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       resend:
         specifier: ^6.9.3
         version: 6.9.3
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -666,6 +669,177 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.16':
+    resolution: {integrity: sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.12':
+    resolution: {integrity: sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.4':
+    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.9':
+    resolution: {integrity: sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.11':
+    resolution: {integrity: sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.6':
+    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.5':
+    resolution: {integrity: sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.5':
+    resolution: {integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.2':
+    resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1011,6 +1185,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -1330,6 +1508,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -1684,6 +1865,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -2419,11 +2604,41 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-smooth@4.0.4:
     resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -2801,6 +3016,26 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -2811,6 +3046,12 @@ packages:
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
@@ -3297,6 +3538,148 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@radix-ui/primitive@1.1.4': {}
+
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-portal@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.5(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.15.0': {}
@@ -3614,6 +3997,10 @@ snapshots:
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   aria-query@5.3.2: {}
 
@@ -3941,6 +4328,8 @@ snapshots:
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   didyoumean@1.2.2: {}
 
@@ -4462,6 +4851,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -5201,6 +5592,25 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react-smooth@4.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       fast-equals: 5.4.0
@@ -5208,6 +5618,14 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-transition-group: 4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -5730,11 +6148,35 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
 
   uuid@8.3.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   victory-vendor@36.9.2:
     dependencies:

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -597,7 +597,7 @@ export function AppShell({ children }: AppShellProps) {
 
       {/* Mobile Bottom Navigation */}
       <nav className="lg:hidden fixed bottom-0 inset-x-0 bg-white/90 backdrop-blur-md border-t border-cream-300/60 z-30 px-2 pb-[env(safe-area-inset-bottom)]">
-        <div className="flex items-center justify-around py-2">
+        <div className="flex items-start justify-around py-2">
           {MOBILE_NAV_ITEMS.map((item) => {
             const isActive = pathname === item.href;
             return (
@@ -605,14 +605,16 @@ export function AppShell({ children }: AppShellProps) {
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  "flex flex-col items-center gap-1 px-3 py-2 rounded-xl transition-all duration-200 min-w-[48px]",
+                  "flex flex-col items-center gap-1 px-1 py-2 rounded-xl transition-all duration-200 flex-1 basis-0 min-w-0",
                   isActive
                     ? "text-amber"
                     : "text-warm-300"
                 )}
               >
-                <item.icon className="w-5 h-5" />
-                <span className="text-[10px] font-medium">{item.label}</span>
+                <item.icon className="w-5 h-5 shrink-0" />
+                <span className="text-[10px] font-medium truncate w-full text-center">
+                  {item.label}
+                </span>
                 {isActive && (
                   <motion.div
                     layoutId="mobile-active"
@@ -629,12 +631,12 @@ export function AppShell({ children }: AppShellProps) {
               onClick={() => setScanOpen(true)}
               disabled={scanLimitReached}
               className={cn(
-                "flex flex-col items-center gap-1 px-3 py-2 rounded-xl transition-all duration-200 min-w-[48px] relative",
+                "flex flex-col items-center gap-1 px-1 py-2 rounded-xl transition-all duration-200 flex-1 basis-0 min-w-0 relative",
                 scanLimitReached ? "text-warm-200 cursor-not-allowed" : "text-warm-300"
               )}
             >
-              <ScanLine className="w-5 h-5" />
-              <span className="text-[10px] font-medium">Scan</span>
+              <ScanLine className="w-5 h-5 shrink-0" />
+              <span className="text-[10px] font-medium truncate w-full text-center">Scan</span>
               {hasLimit && (
                 <span className={cn(
                   "text-[9px] font-medium",

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -3,7 +3,6 @@
 import { useState, useCallback } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
-import { signOut } from "next-auth/react";
 import {
   LayoutDashboard,
   BarChart3,
@@ -11,9 +10,7 @@ import {
   CalendarClock,
   Tags,
   Tag,
-  LogOut,
   Wallet,
-  User,
   ScanLine,
   Shield,
   AlertTriangle,
@@ -21,6 +18,7 @@ import {
 import { cn, compressImage, formatDateInput, toLocalDateString } from "@/lib/utils";
 import { motion } from "framer-motion";
 import { useUser } from "@/components/user-provider";
+import { ProfileMenu } from "@/components/profile-menu";
 import { ScanProvider } from "@/components/scan-provider";
 import { ScanReceiptSheet } from "@/components/scan-receipt-sheet";
 import { Modal } from "@/components/ui/modal";
@@ -57,8 +55,12 @@ const NAV_ITEMS = [
   { href: "/labels", label: "Labels", icon: Tag },
 ];
 
-/** Mobile bottom nav excludes Labels to avoid overflow on narrow viewports */
-const MOBILE_NAV_ITEMS = NAV_ITEMS.filter((item) => item.href !== "/labels");
+/** Hidden from the mobile bottom nav — reachable via the profile menu instead.
+ *  Labels avoids overflow; Bills/Categories live in the profile menu. */
+const MOBILE_NAV_EXCLUDED = ["/labels", "/bills", "/categories"];
+const MOBILE_NAV_ITEMS = NAV_ITEMS.filter(
+  (item) => !MOBILE_NAV_EXCLUDED.includes(item.href)
+);
 
 export function AppShell({ children }: AppShellProps) {
   const pathname = usePathname();
@@ -574,45 +576,22 @@ export function AppShell({ children }: AppShellProps) {
               </span>
             </div>
           )}
-          <Link
-            href="/profile"
-            className="flex items-center gap-3 px-2 mb-3 rounded-xl py-1 -mx-0 hover:bg-cream-100 transition-colors"
-          >
-            <div className="w-9 h-9 rounded-full bg-cream-200 flex items-center justify-center">
-              <User className="w-4 h-4 text-warm-400" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-warm-600 truncate">
-                {user.name}
-              </p>
-              <p className="text-xs text-warm-400 truncate">{user.email}</p>
-            </div>
-          </Link>
-          <button
-            onClick={() => signOut({ callbackUrl: "/login" })}
-            className="flex items-center gap-2 w-full px-4 py-2.5 rounded-xl text-sm text-warm-400 hover:text-expense hover:bg-expense-light transition-all duration-200"
-          >
-            <LogOut className="w-4 h-4" />
-            Sign Out
-          </button>
+          <ProfileMenu
+            variant="desktop"
+            name={user.name}
+            email={user.email}
+            isAdmin={user.role === "ADMIN"}
+          />
         </div>
       </aside>
 
       {/* Mobile Header */}
       <header className="lg:hidden fixed top-0 inset-x-0 bg-white/90 backdrop-blur-md border-b border-cream-300/60 z-30 px-4 py-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2.5">
-            <div className="w-9 h-9 rounded-xl bg-amber text-white flex items-center justify-center shadow-soft">
-              <Wallet className="w-4 h-4" />
-            </div>
-            <h1 className="font-serif text-lg text-warm-700">Budget Tracker</h1>
+        <div className="flex items-center gap-2.5">
+          <div className="w-9 h-9 rounded-xl bg-amber text-white flex items-center justify-center shadow-soft">
+            <Wallet className="w-4 h-4" />
           </div>
-          <Link
-            href="/profile"
-            className="p-2 rounded-xl text-warm-400 hover:text-warm-600 hover:bg-cream-100 transition-colors"
-          >
-            <User className="w-5 h-5" />
-          </Link>
+          <h1 className="font-serif text-lg text-warm-700">Budget Tracker</h1>
         </div>
       </header>
 
@@ -666,6 +645,13 @@ export function AppShell({ children }: AppShellProps) {
               )}
             </button>
           )}
+          <ProfileMenu
+            variant="mobile"
+            triggerStyle="tab"
+            name={user.name}
+            email={user.email}
+            isAdmin={user.role === "ADMIN"}
+          />
         </div>
       </nav>
 

--- a/src/components/profile-menu.tsx
+++ b/src/components/profile-menu.tsx
@@ -101,6 +101,7 @@ function buildMenuItems({
 function useCloseOnDesktop(setOpen: Dispatch<SetStateAction<boolean>>) {
   useEffect(() => {
     const mql = window.matchMedia("(min-width: 1024px)");
+    if (mql.matches) setOpen(false);
     const handler = (e: MediaQueryListEvent) => {
       if (e.matches) setOpen(false);
     };
@@ -289,6 +290,8 @@ function DesktopMenu({ open, setOpen, name, email, items, onSelect }: MenuViewPr
       <button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
+        aria-haspopup="menu"
+        aria-expanded={open}
         className="flex items-center gap-3 w-full px-2 py-1 rounded-xl text-left hover:bg-cream-100 transition-colors"
       >
         <div className="w-9 h-9 rounded-full bg-cream-200 flex items-center justify-center shrink-0">

--- a/src/components/profile-menu.tsx
+++ b/src/components/profile-menu.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type ComponentType,
   type Dispatch,
+  type RefObject,
   type SetStateAction,
 } from "react";
 import { useRouter } from "next/navigation";
@@ -56,20 +57,21 @@ interface MenuViewProps {
   onSelect: (item: MenuItem) => void;
 }
 
-/** Account + quick-nav menu. Renders a bottom sheet (Vaul) on mobile and an
- *  anchored dropdown on desktop, sharing one item list. */
-export function ProfileMenu({
-  variant,
-  name,
-  email,
-  isAdmin,
-  triggerStyle = "icon",
-}: ProfileMenuProps) {
-  const [open, setOpen] = useState(false);
-  const router = useRouter();
-  const { hideAmounts, toggleHideAmounts } = usePrivacy();
+interface BuildMenuItemsArgs {
+  isAdmin: boolean;
+  hideAmounts: boolean;
+  router: ReturnType<typeof useRouter>;
+  toggleHideAmounts: () => void;
+}
 
-  const items: MenuItem[] = [
+/** Builds the shared menu item list (data only — no rendering). */
+function buildMenuItems({
+  isAdmin,
+  hideAmounts,
+  router,
+  toggleHideAmounts,
+}: BuildMenuItemsArgs): MenuItem[] {
+  return [
     { key: "profile", label: "My Profile", icon: User, onSelect: () => router.push("/profile") },
     { key: "bills", label: "Bills", icon: CalendarClock, onSelect: () => router.push("/bills"), mobileOnly: true },
     { key: "categories", label: "Categories", icon: Tags, onSelect: () => router.push("/categories"), mobileOnly: true },
@@ -91,6 +93,63 @@ export function ProfileMenu({
       danger: true,
     },
   ];
+}
+
+/** Closes the mobile sheet once the viewport reaches the desktop (lg) breakpoint.
+ *  Vaul portals the sheet onto document.body, so `lg:hidden` on the trigger won't
+ *  unmount or hide an already-open sheet after a resize/rotation. */
+function useCloseOnDesktop(setOpen: Dispatch<SetStateAction<boolean>>) {
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 1024px)");
+    const handler = (e: MediaQueryListEvent) => {
+      if (e.matches) setOpen(false);
+    };
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [setOpen]);
+}
+
+/** Closes the desktop dropdown on outside-click or Escape. */
+function useDesktopDismiss(
+  open: boolean,
+  setOpen: Dispatch<SetStateAction<boolean>>,
+  containerRef: RefObject<HTMLDivElement | null>
+) {
+  useEffect(() => {
+    if (!open) return;
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, setOpen, containerRef]);
+}
+
+/** Account + quick-nav menu. Renders a bottom sheet (Vaul) on mobile and an
+ *  anchored dropdown on desktop, sharing one item list. */
+export function ProfileMenu({
+  variant,
+  name,
+  email,
+  isAdmin,
+  triggerStyle = "icon",
+}: ProfileMenuProps) {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+  const { hideAmounts, toggleHideAmounts } = usePrivacy();
+
+  const items = buildMenuItems({ isAdmin, hideAmounts, router, toggleHideAmounts });
 
   const handleSelect = (item: MenuItem) => {
     item.onSelect();
@@ -141,6 +200,30 @@ function MenuRow({
   );
 }
 
+/** Renders the item list with a divider before "Log out". */
+function MenuList({
+  items,
+  onSelect,
+  size,
+}: {
+  items: MenuItem[];
+  onSelect: (item: MenuItem) => void;
+  size: "sm" | "lg";
+}) {
+  return (
+    <>
+      {items.map((item) => (
+        <Fragment key={item.key}>
+          {item.key === "logout" && (
+            <div className={cn("border-t border-cream-200/80", size === "lg" && "my-2")} />
+          )}
+          <MenuRow item={item} onSelect={onSelect} size={size} />
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
 function MobileMenu({
   open,
   setOpen,
@@ -150,6 +233,8 @@ function MobileMenu({
   onSelect,
   triggerStyle,
 }: MenuViewProps & { triggerStyle: "icon" | "tab" }) {
+  useCloseOnDesktop(setOpen);
+
   return (
     <Drawer.Root open={open} onOpenChange={setOpen}>
       <Drawer.Trigger
@@ -187,12 +272,7 @@ function MobileMenu({
             </div>
           </div>
           <div className="py-2">
-            {items.map((item) => (
-              <Fragment key={item.key}>
-                {item.key === "logout" && <div className="my-2 border-t border-cream-200/80" />}
-                <MenuRow item={item} onSelect={onSelect} size="lg" />
-              </Fragment>
-            ))}
+            <MenuList items={items} onSelect={onSelect} size="lg" />
           </div>
         </Drawer.Content>
       </Drawer.Portal>
@@ -202,26 +282,7 @@ function MobileMenu({
 
 function DesktopMenu({ open, setOpen, name, email, items, onSelect }: MenuViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-
-    const handleMouseDown = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-
-    document.addEventListener("mousedown", handleMouseDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleMouseDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open, setOpen]);
+  useDesktopDismiss(open, setOpen, containerRef);
 
   return (
     <div ref={containerRef} className="relative">
@@ -248,12 +309,7 @@ function DesktopMenu({ open, setOpen, name, email, items, onSelect }: MenuViewPr
             transition={{ duration: 0.15 }}
             className="absolute bottom-full left-0 right-0 mb-2 bg-white rounded-xl shadow-soft-lg border border-cream-300/60 overflow-hidden z-50"
           >
-            {items.map((item) => (
-              <Fragment key={item.key}>
-                {item.key === "logout" && <div className="border-t border-cream-200/80" />}
-                <MenuRow item={item} onSelect={onSelect} size="sm" />
-              </Fragment>
-            ))}
+            <MenuList items={items} onSelect={onSelect} size="sm" />
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/profile-menu.tsx
+++ b/src/components/profile-menu.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import {
+  Fragment,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentType,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { useRouter } from "next/navigation";
+import { signOut } from "next-auth/react";
+import { Drawer } from "vaul";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  User,
+  CalendarClock,
+  Tags,
+  Shield,
+  LogOut,
+  Eye,
+  EyeOff,
+  type LucideProps,
+} from "lucide-react";
+import { usePrivacy } from "@/components/privacy-provider";
+import { cn } from "@/lib/utils";
+
+interface MenuItem {
+  key: string;
+  label: string;
+  icon: ComponentType<LucideProps>;
+  onSelect: () => void;
+  /** Toggles keep the menu open so the user sees the state change */
+  keepOpen?: boolean;
+  danger?: boolean;
+  /** Hidden from the desktop dropdown (already in the desktop sidebar nav) */
+  mobileOnly?: boolean;
+}
+
+interface ProfileMenuProps {
+  variant: "mobile" | "desktop";
+  name: string;
+  email: string;
+  isAdmin: boolean;
+  /** Mobile trigger appearance: a header icon button or a bottom-nav tab */
+  triggerStyle?: "icon" | "tab";
+}
+
+interface MenuViewProps {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+  name: string;
+  email: string;
+  items: MenuItem[];
+  onSelect: (item: MenuItem) => void;
+}
+
+/** Account + quick-nav menu. Renders a bottom sheet (Vaul) on mobile and an
+ *  anchored dropdown on desktop, sharing one item list. */
+export function ProfileMenu({
+  variant,
+  name,
+  email,
+  isAdmin,
+  triggerStyle = "icon",
+}: ProfileMenuProps) {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+  const { hideAmounts, toggleHideAmounts } = usePrivacy();
+
+  const items: MenuItem[] = [
+    { key: "profile", label: "My Profile", icon: User, onSelect: () => router.push("/profile") },
+    { key: "bills", label: "Bills", icon: CalendarClock, onSelect: () => router.push("/bills"), mobileOnly: true },
+    { key: "categories", label: "Categories", icon: Tags, onSelect: () => router.push("/categories"), mobileOnly: true },
+    ...(isAdmin
+      ? [{ key: "admin", label: "Admin", icon: Shield, onSelect: () => router.push("/admin") }]
+      : []),
+    {
+      key: "privacy",
+      label: hideAmounts ? "Show amounts" : "Hide amounts",
+      icon: hideAmounts ? Eye : EyeOff,
+      onSelect: toggleHideAmounts,
+      keepOpen: true,
+    },
+    {
+      key: "logout",
+      label: "Log out",
+      icon: LogOut,
+      onSelect: () => signOut({ callbackUrl: "/login" }),
+      danger: true,
+    },
+  ];
+
+  const handleSelect = (item: MenuItem) => {
+    item.onSelect();
+    if (!item.keepOpen) setOpen(false);
+  };
+
+  const visibleItems = variant === "desktop" ? items.filter((item) => !item.mobileOnly) : items;
+
+  const viewProps: MenuViewProps = {
+    open,
+    setOpen,
+    name,
+    email,
+    items: visibleItems,
+    onSelect: handleSelect,
+  };
+
+  return variant === "mobile" ? (
+    <MobileMenu {...viewProps} triggerStyle={triggerStyle} />
+  ) : (
+    <DesktopMenu {...viewProps} />
+  );
+}
+
+/** Shared row used by both layouts. */
+function MenuRow({
+  item,
+  onSelect,
+  size,
+}: {
+  item: MenuItem;
+  onSelect: (item: MenuItem) => void;
+  size: "sm" | "lg";
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item)}
+      className={cn(
+        "flex items-center gap-3 w-full text-left transition-colors",
+        size === "lg" ? "px-6 py-3.5 text-[15px]" : "px-4 py-3 text-sm",
+        item.danger ? "text-expense hover:bg-expense-light" : "text-warm-600 hover:bg-cream-50"
+      )}
+    >
+      <item.icon className={cn("shrink-0", size === "lg" ? "w-5 h-5" : "w-4 h-4")} />
+      <span className="font-medium">{item.label}</span>
+    </button>
+  );
+}
+
+function MobileMenu({
+  open,
+  setOpen,
+  name,
+  email,
+  items,
+  onSelect,
+  triggerStyle,
+}: MenuViewProps & { triggerStyle: "icon" | "tab" }) {
+  return (
+    <Drawer.Root open={open} onOpenChange={setOpen}>
+      <Drawer.Trigger
+        aria-label="Open profile menu"
+        className={cn(
+          "transition-colors",
+          triggerStyle === "tab"
+            ? "flex flex-col items-center gap-1 px-3 py-2 rounded-xl min-w-[48px] text-warm-300 hover:text-warm-600"
+            : "p-2 rounded-xl text-warm-400 hover:text-warm-600 hover:bg-cream-100"
+        )}
+      >
+        <User className="w-5 h-5" />
+        {triggerStyle === "tab" && <span className="text-[10px] font-medium">Profile</span>}
+      </Drawer.Trigger>
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 bg-warm-900/30 backdrop-blur-sm z-50" />
+        <Drawer.Content className="fixed bottom-0 inset-x-0 z-50 flex flex-col bg-white rounded-t-2xl shadow-soft-lg grain-overlay pb-[env(safe-area-inset-bottom)] focus:outline-none">
+          <Drawer.Description className="sr-only">
+            Account and quick navigation menu
+          </Drawer.Description>
+          <div className="flex justify-center pt-3 pb-1 shrink-0">
+            <div className="w-10 h-1 rounded-full bg-cream-300" />
+          </div>
+          <div className="flex items-center gap-3 px-6 py-4 border-b border-cream-200/80">
+            <div className="w-10 h-10 rounded-full bg-cream-200 flex items-center justify-center shrink-0">
+              <User className="w-5 h-5 text-warm-400" />
+            </div>
+            <div className="min-w-0">
+              <Drawer.Title className="text-sm font-medium text-warm-700 truncate">
+                {name}
+              </Drawer.Title>
+              <p className="text-xs text-warm-400 truncate">{email}</p>
+            </div>
+          </div>
+          <div className="py-2">
+            {items.map((item) => (
+              <Fragment key={item.key}>
+                {item.key === "logout" && <div className="my-2 border-t border-cream-200/80" />}
+                <MenuRow item={item} onSelect={onSelect} size="lg" />
+              </Fragment>
+            ))}
+          </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+}
+
+function DesktopMenu({ open, setOpen, name, email, items, onSelect }: MenuViewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, setOpen]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex items-center gap-3 w-full px-2 py-1 rounded-xl text-left hover:bg-cream-100 transition-colors"
+      >
+        <div className="w-9 h-9 rounded-full bg-cream-200 flex items-center justify-center shrink-0">
+          <User className="w-4 h-4 text-warm-400" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-warm-600 truncate">{name}</p>
+          <p className="text-xs text-warm-400 truncate">{email}</p>
+        </div>
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 4 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 4 }}
+            transition={{ duration: 0.15 }}
+            className="absolute bottom-full left-0 right-0 mb-2 bg-white rounded-xl shadow-soft-lg border border-cream-300/60 overflow-hidden z-50"
+          >
+            {items.map((item) => (
+              <Fragment key={item.key}>
+                {item.key === "logout" && <div className="border-t border-cream-200/80" />}
+                <MenuRow item={item} onSelect={onSelect} size="sm" />
+              </Fragment>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/profile-menu.tsx
+++ b/src/components/profile-menu.tsx
@@ -157,12 +157,14 @@ function MobileMenu({
         className={cn(
           "transition-colors",
           triggerStyle === "tab"
-            ? "flex flex-col items-center gap-1 px-3 py-2 rounded-xl min-w-[48px] text-warm-300 hover:text-warm-600"
+            ? "flex flex-col items-center gap-1 px-1 py-2 rounded-xl flex-1 basis-0 min-w-0 text-warm-300 hover:text-warm-600"
             : "p-2 rounded-xl text-warm-400 hover:text-warm-600 hover:bg-cream-100"
         )}
       >
-        <User className="w-5 h-5" />
-        {triggerStyle === "tab" && <span className="text-[10px] font-medium">Profile</span>}
+        <User className="w-5 h-5 shrink-0" />
+        {triggerStyle === "tab" && (
+          <span className="text-[10px] font-medium truncate w-full text-center">Profile</span>
+        )}
       </Drawer.Trigger>
       <Drawer.Portal>
         <Drawer.Overlay className="fixed inset-0 bg-warm-900/30 backdrop-blur-sm z-50" />


### PR DESCRIPTION
## Summary
Tapping the profile entry now opens an **account & quick-nav menu** instead of navigating straight to `/profile`.

- **Mobile** — native-style **bottom sheet** (drag-to-dismiss) built with [`vaul`](https://www.npmjs.com/package/vaul) `@1.1.2`
- **Desktop** — anchored **dropdown** opening upward from the sidebar profile row (Framer Motion, matching the existing `dropdown-button` pattern)
- New component: `src/components/profile-menu.tsx`

### Menu contents
| Item | Mobile sheet | Desktop dropdown |
|---|---|---|
| My Profile | ✅ | ✅ |
| Bills | ✅ | ❌ (in sidebar nav) |
| Categories | ✅ | ❌ (in sidebar nav) |
| Admin *(admins only)* | ✅ | ✅ |
| Hide/Show amounts *(inline toggle)* | ✅ | ✅ |
| Log out | ✅ | ✅ |

### Mobile nav reorganization
- Profile trigger **moved** from the top header (now logo/title only) into the **bottom nav** as a `Profile` tab
- **Bills & Categories removed** from the mobile bottom nav (reachable via the menu)
- Bottom nav is now: Dashboard · Transactions · Analytics · (Scan) · Profile

### Desktop
- Standalone sidebar **"Sign Out" button folded** into the dropdown
- Sidebar nav unchanged

## Notes / Risks
- New dependency: `vaul@1.1.2` (React 19 compatible; built on Radix Dialog)
- The mobile Profile tab has no active-route highlight (it's an action, not a destination)
- Hide-amounts toggle flips inline via `usePrivacy()` and keeps the menu open for feedback

## Test plan
- [ ] Mobile: bottom-nav **Profile** tab opens the sheet; swipe-down/tap-outside dismisses
- [ ] Mobile: **Hide amounts** toggles inline, sheet stays open
- [ ] Mobile: top header shows only logo/title; bottom nav has no Bills/Categories
- [ ] Desktop: clicking the sidebar profile row opens the dropdown upward; click-outside / Esc closes
- [ ] Desktop dropdown has no Bills/Categories; **Log out** redirects to `/login`
- [ ] Non-admin user: no **Admin** row in either layout

## Verification
- ✅ `pnpm type-check`
- ✅ `pnpm lint` (No ESLint warnings or errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and UI-only changes reusing existing auth sign-out and preferences APIs; new vaul dependency is localized to the profile menu.
> 
> **Overview**
> Profile entry no longer jumps straight to `/profile` — it opens a shared **account & quick-nav menu** wired through new `ProfileMenu` in the app shell.
> 
> On **mobile**, the menu is a **Vaul** bottom sheet (drag handle, overlay, safe-area padding) with a **Profile** tab in the bottom nav; the header profile icon is removed so the top bar is logo/title only. **Bills** and **Categories** are dropped from the bottom nav and exposed only in the mobile sheet (desktop sidebar nav is unchanged).
> 
> On **desktop**, the sidebar profile row and standalone **Sign out** control are replaced by an upward **dropdown** (outside-click / Escape dismiss) with the same actions except mobile-only Bills/Categories.
> 
> Menu actions include My Profile, Admin (when applicable), inline **Hide/Show amounts** via `usePrivacy()` (menu stays open), and **Log out** via `signOut`. Adds **`vaul@1.1.2`** plus lockfile/Radix transitives; changelog and `.gitignore` tweaks for env patterns and local tool artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b5b776f71944c389f4f356f4fa2f993fef1f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new profile menu for account navigation and settings
  * Mobile profile menu displays as a bottom sheet; desktop as a dropdown menu
  * Integrated privacy toggle to hide/show transaction amounts
  * Moved sign-out action into the profile menu
  * Mobile bottom navigation now includes a dedicated Profile tab

<!-- end of auto-generated comment: release notes by coderabbit.ai -->