### PR TITLE
feat(analytics): redesign Stats & Health tabs for mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable development history for the Budget Tracker app.
 
+## 2026-06-15 — Analytics Stats & Health mobile redesign
+
+### Stats (Records & Statistics) tab
+- Replaced the uniform 3-box grid with a content-fit layout: **Top Records** now shows Biggest Expense & Income as two featured tiles plus a full-width "Most Expensive Day" banner; Averages, Activity, and Category Insights render as clean **list rows** (icon + label left, value right) with dividers
+- Tighter card padding on mobile (`p-4 sm:p-5`); long category/description text truncates gracefully
+
+### Health (Financial Health) tab
+- Overall score is now a horizontal **gauge + text hero** on mobile (was a tall centered stack); faint band-colored halo behind the ring gauge
+- Sub-scores use a **2-up grid** on mobile (5th spans full width) with a **mini progress bar** (score/100, color-banded) under each score and 2-line clamped descriptions
+- Privacy masking, empty-state `—` handling, and tablet/desktop layouts unchanged
+
 ## 2026-06-15 — Profile Menu
 
 ### Account & Quick-Nav Menu

--- a/src/components/analytics/financial-health-score.tsx
+++ b/src/components/analytics/financial-health-score.tsx
@@ -27,6 +27,15 @@ const SCORE_COLORS: Record<string, { text: string; stroke: string; bg: string }>
   Critical: { text: "text-red-600", stroke: "stroke-red-500", bg: "bg-red-50" },
 };
 
+/** Fill color for a sub-score progress bar, banded to mirror SCORE_COLORS. */
+function scoreBarClass(score: number): string {
+  if (score >= 80) return "bg-emerald-500";
+  if (score >= 60) return "bg-green-500";
+  if (score >= 40) return "bg-amber-500";
+  if (score >= 20) return "bg-orange-500";
+  return "bg-red-500";
+}
+
 const TREND_CONFIG: Record<HealthTrend, { icon: typeof TrendingUp; color: string; label: string }> = {
   improving: { icon: TrendingUp, color: "text-green-500", label: "Improving" },
   declining: { icon: TrendingDown, color: "text-red-500", label: "Declining" },
@@ -50,7 +59,7 @@ function ScoreGauge({ score, label }: { score: number; label: string }) {
   const offset = CIRCUMFERENCE * (1 - score / 100);
 
   return (
-    <div className="relative w-[120px] h-[120px] flex-shrink-0">
+    <div className={cn("relative w-[120px] h-[120px] flex-shrink-0 rounded-full", colors.bg)}>
       <svg viewBox="0 0 120 120" className="w-full h-full -rotate-90">
         <circle
           cx="60"
@@ -93,11 +102,11 @@ function TrendBadge({ trend }: { trend: HealthTrend }) {
   );
 }
 
-function SubScoreCard({ subScore, iconKey }: { subScore: HealthSubScore; iconKey: keyof typeof SUB_SCORE_ICONS }) {
+function SubScoreCard({ subScore, iconKey, className }: { subScore: HealthSubScore; iconKey: keyof typeof SUB_SCORE_ICONS; className?: string }) {
   const { icon: Icon, color, bg } = SUB_SCORE_ICONS[iconKey];
 
   return (
-    <div className="p-3 rounded-xl bg-cream-50/50">
+    <div className={cn("p-3 rounded-xl bg-cream-50/50", className)}>
       <div className="flex items-center justify-between mb-2">
         <div className={cn("w-8 h-8 rounded-lg flex items-center justify-center", bg)}>
           <Icon className={cn("w-4 h-4", color)} />
@@ -108,7 +117,15 @@ function SubScoreCard({ subScore, iconKey }: { subScore: HealthSubScore; iconKey
         {subScore.label}
       </p>
       <p className="text-lg font-serif text-warm-700">{subScore.score}<span className="text-sm text-warm-300">/100</span></p>
-      <p className="text-xs text-warm-300 mt-0.5">{subScore.description}</p>
+      <div className="mt-1.5 h-1.5 w-full rounded-full bg-cream-200 overflow-hidden">
+        <motion.div
+          className={cn("h-full rounded-full", scoreBarClass(subScore.score))}
+          initial={{ width: 0 }}
+          animate={{ width: `${Math.max(0, Math.min(100, subScore.score))}%` }}
+          transition={{ duration: 0.8, ease: "easeOut" }}
+        />
+      </div>
+      <p className="text-xs text-warm-300 mt-1.5 line-clamp-2">{subScore.description}</p>
     </div>
   );
 }
@@ -119,12 +136,12 @@ export function FinancialHealthScore({ healthScore: h }: FinancialHealthScorePro
   return (
     <motion.div variants={stagger} initial="hidden" animate="show" className="space-y-4">
       {/* Overall Score */}
-      <motion.div variants={fadeUp} className="card p-5">
-        <div className="flex flex-col sm:flex-row items-center gap-5">
+      <motion.div variants={fadeUp} className="card p-4 sm:p-5">
+        <div className="flex flex-row items-center gap-4 sm:gap-5">
           <ScoreGauge score={h.overallScore} label={h.overallLabel} />
-          <div className="text-center sm:text-left">
+          <div className="min-w-0 text-left">
             <h2 className="font-serif text-lg text-warm-700">Financial Health</h2>
-            <div className="flex items-center justify-center sm:justify-start gap-2 mt-1">
+            <div className="flex items-center justify-start gap-2 mt-1">
               <TrendBadge trend={h.overallTrend} />
             </div>
             {h.savingsRate !== null && (
@@ -144,15 +161,15 @@ export function FinancialHealthScore({ healthScore: h }: FinancialHealthScorePro
       </motion.div>
 
       {/* Sub-scores */}
-      <motion.div variants={fadeUp} className="card p-5">
+      <motion.div variants={fadeUp} className="card p-4 sm:p-5">
         <h2 className="font-serif text-lg text-warm-700">Score Breakdown</h2>
-        <p className="text-xs text-warm-300 mb-4">What makes up your financial health score</p>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        <p className="text-xs text-warm-300 mb-3 sm:mb-4">What makes up your financial health score</p>
+        <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
           <SubScoreCard subScore={h.subScores.savingsRate} iconKey="savingsRate" />
           <SubScoreCard subScore={h.subScores.expenseTrend} iconKey="expenseTrend" />
           <SubScoreCard subScore={h.subScores.incomeStability} iconKey="incomeStability" />
           <SubScoreCard subScore={h.subScores.diversification} iconKey="diversification" />
-          <SubScoreCard subScore={h.subScores.consistency} iconKey="consistency" />
+          <SubScoreCard subScore={h.subScores.consistency} iconKey="consistency" className="col-span-2 sm:col-span-1" />
         </div>
       </motion.div>
     </motion.div>

--- a/src/components/analytics/records-statistics.tsx
+++ b/src/components/analytics/records-statistics.tsx
@@ -26,38 +26,8 @@ interface RecordsStatisticsProps {
   hideAmounts: boolean;
 }
 
-function StatItem({
-  icon: Icon,
-  iconColor,
-  iconBg,
-  label,
-  value,
-  subtitle,
-}: {
-  icon: typeof Hash;
-  iconColor: string;
-  iconBg: string;
-  label: string;
-  value: string;
-  subtitle?: string;
-}) {
-  return (
-    <div className="p-3 rounded-xl bg-cream-50/50">
-      <div className="flex items-center gap-2 mb-2">
-        <div className={cn("w-8 h-8 rounded-lg flex items-center justify-center", iconBg)}>
-          <Icon className={cn("w-4 h-4", iconColor)} />
-        </div>
-      </div>
-      <p className="text-[10px] font-medium tracking-wider text-warm-400 uppercase mb-0.5">
-        {label}
-      </p>
-      <p className="text-lg font-serif text-warm-700">{value}</p>
-      {subtitle && <p className="text-xs text-warm-300 mt-0.5">{subtitle}</p>}
-    </div>
-  );
-}
-
-function TopRecordItem({
+/** Prominent tile for a notable transaction record (Biggest Expense / Income). */
+function FeaturedRecord({
   icon: Icon,
   iconColor,
   iconBg,
@@ -75,27 +45,57 @@ function TopRecordItem({
   hideAmounts: boolean;
 }) {
   const sym = getCurrencySymbol(currency);
-  if (!record) {
-    return <StatItem icon={Icon} iconColor={iconColor} iconBg={iconBg} label={label} value="—" />;
-  }
-
   return (
-    <div className="p-3 rounded-xl bg-cream-50/50">
+    <div className="p-3.5 rounded-xl bg-cream-50/60 border border-cream-200/60">
       <div className="flex items-center gap-2 mb-2">
-        <div className={cn("w-8 h-8 rounded-lg flex items-center justify-center", iconBg)}>
+        <div className={cn("w-8 h-8 rounded-lg flex items-center justify-center shrink-0", iconBg)}>
           <Icon className={cn("w-4 h-4", iconColor)} />
         </div>
+        <p className="text-[10px] font-medium tracking-wider text-warm-400 uppercase truncate">
+          {label}
+        </p>
       </div>
-      <p className="text-[10px] font-medium tracking-wider text-warm-400 uppercase mb-0.5">
-        {label}
+      <p className="text-xl font-serif text-warm-700 truncate tabular-nums">
+        {record ? (hideAmounts ? `${sym} ••••••` : formatCurrency(record.amount, currency)) : "—"}
       </p>
-      <p className="text-lg font-serif text-warm-700">
-        {hideAmounts ? `${sym} ••••••` : formatCurrency(record.amount, currency)}
-      </p>
-      <div className="flex items-center gap-1.5 mt-1">
-        <CategoryIcon name={record.categoryIcon} className="w-3 h-3" style={{ color: record.categoryColor }} />
-        <span className="text-xs text-warm-300 truncate">{record.description} · {record.date}</span>
+      {record && (
+        <div className="flex items-center gap-1.5 mt-1 min-w-0">
+          <CategoryIcon name={record.categoryIcon} className="w-3 h-3 shrink-0" style={{ color: record.categoryColor }} />
+          <span className="text-xs text-warm-300 truncate">{record.description} · {record.date}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Scannable list row: icon + label on the left, value (+ subtitle) on the right. */
+function MetricRow({
+  icon: Icon,
+  iconColor,
+  iconBg,
+  label,
+  value,
+  subtitle,
+}: {
+  icon: typeof Hash;
+  iconColor: string;
+  iconBg: string;
+  label: string;
+  value: string;
+  subtitle?: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 py-2.5">
+      <div className={cn("w-9 h-9 rounded-lg flex items-center justify-center shrink-0", iconBg)}>
+        <Icon className={cn("w-4 h-4", iconColor)} />
       </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-warm-600 truncate">{label}</p>
+        {subtitle && <p className="text-xs text-warm-300 truncate">{subtitle}</p>}
+      </div>
+      <p className="text-base font-serif text-warm-700 shrink-0 max-w-[45%] truncate text-right tabular-nums">
+        {value}
+      </p>
     </div>
   );
 }
@@ -107,68 +107,60 @@ export function RecordsStatistics({ statistics: s, currency, hideAmounts }: Reco
 
   return (
     <motion.div variants={stagger} initial="hidden" animate="show" className="space-y-4">
-      {/* Top Records */}
-      <motion.div variants={fadeUp} className="card p-5">
+      {/* Top Records — featured tiles + priciest-day banner */}
+      <motion.div variants={fadeUp} className="card p-4 sm:p-5">
         <h2 className="font-serif text-lg text-warm-700">Top Records</h2>
-        <p className="text-xs text-warm-300 mb-4">Notable transactions this period</p>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <TopRecordItem icon={ArrowDownRight} iconColor="text-expense" iconBg="bg-expense-light" label="Biggest Expense" record={s.biggestExpense} currency={currency} hideAmounts={hideAmounts} />
-          <TopRecordItem icon={ArrowUpRight} iconColor="text-income" iconBg="bg-income-light" label="Biggest Income" record={s.biggestIncome} currency={currency} hideAmounts={hideAmounts} />
-          <StatItem
-            icon={CalendarDays}
-            iconColor="text-amber-600"
-            iconBg="bg-amber-50"
-            label="Most Expensive Day"
-            value={s.mostExpensiveDay ? fmt(s.mostExpensiveDay.total) : "—"}
-            subtitle={s.mostExpensiveDay ? `${s.mostExpensiveDay.date} · ${s.mostExpensiveDay.count} txns` : undefined}
-          />
+        <p className="text-xs text-warm-300 mb-3">Notable transactions this period</p>
+        <div className="grid grid-cols-2 gap-3">
+          <FeaturedRecord icon={ArrowDownRight} iconColor="text-expense" iconBg="bg-expense-light" label="Biggest Expense" record={s.biggestExpense} currency={currency} hideAmounts={hideAmounts} />
+          <FeaturedRecord icon={ArrowUpRight} iconColor="text-income" iconBg="bg-income-light" label="Biggest Income" record={s.biggestIncome} currency={currency} hideAmounts={hideAmounts} />
+        </div>
+        <div className="mt-3 flex items-center gap-3 p-3 rounded-xl bg-amber-50/70">
+          <div className="w-9 h-9 rounded-lg bg-amber-100 flex items-center justify-center shrink-0">
+            <CalendarDays className="w-4 h-4 text-amber-600" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-warm-600">Most Expensive Day</p>
+            {s.mostExpensiveDay && (
+              <p className="text-xs text-warm-300 truncate">{s.mostExpensiveDay.date} · {s.mostExpensiveDay.count} txns</p>
+            )}
+          </div>
+          <p className="text-base font-serif text-warm-700 shrink-0 tabular-nums">
+            {s.mostExpensiveDay ? fmt(s.mostExpensiveDay.total) : "—"}
+          </p>
         </div>
       </motion.div>
 
       {/* Averages */}
-      <motion.div variants={fadeUp} className="card p-5">
+      <motion.div variants={fadeUp} className="card p-4 sm:p-5">
         <h2 className="font-serif text-lg text-warm-700">Averages</h2>
-        <p className="text-xs text-warm-300 mb-4">Per-day and per-transaction averages</p>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <StatItem icon={Calculator} iconColor="text-expense" iconBg="bg-expense-light" label="Daily Spend" value={fmt(s.avgDailySpend)} subtitle={s.avgDailySpend !== null ? `Over ${s.totalDaysInPeriod} days` : undefined} />
-          <StatItem icon={Receipt} iconColor="text-warm-500" iconBg="bg-cream-100" label="Per Expense" value={fmt(s.avgExpenseSize)} />
-          <StatItem icon={Coins} iconColor="text-income" iconBg="bg-income-light" label="Per Income" value={fmt(s.avgIncomeSize)} />
+        <p className="text-xs text-warm-300 mb-1">Per-day and per-transaction averages</p>
+        <div className="divide-y divide-cream-200/70">
+          <MetricRow icon={Calculator} iconColor="text-expense" iconBg="bg-expense-light" label="Daily Spend" value={fmt(s.avgDailySpend)} subtitle={s.avgDailySpend !== null ? `Over ${s.totalDaysInPeriod} days` : undefined} />
+          <MetricRow icon={Receipt} iconColor="text-warm-500" iconBg="bg-cream-100" label="Per Expense" value={fmt(s.avgExpenseSize)} />
+          <MetricRow icon={Coins} iconColor="text-income" iconBg="bg-income-light" label="Per Income" value={fmt(s.avgIncomeSize)} />
         </div>
       </motion.div>
 
       {/* Activity */}
-      <motion.div variants={fadeUp} className="card p-5">
+      <motion.div variants={fadeUp} className="card p-4 sm:p-5">
         <h2 className="font-serif text-lg text-warm-700">Activity</h2>
-        <p className="text-xs text-warm-300 mb-4">Transaction frequency and streaks</p>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <StatItem icon={Hash} iconColor="text-warm-600" iconBg="bg-cream-100" label="Transactions" value={s.totalTransactions.toLocaleString()} />
-          <StatItem icon={CalendarCheck} iconColor="text-blue-500" iconBg="bg-blue-50" label="Active Days" value={`${s.activeDays} / ${s.totalDaysInPeriod}`} subtitle={s.totalDaysInPeriod > 0 ? `${Math.round((s.activeDays / s.totalDaysInPeriod) * 100)}% of days` : undefined} />
-          <StatItem icon={Flame} iconColor="text-orange-500" iconBg="bg-orange-50" label="Spending Streak" value={s.spendingStreak > 0 ? `${s.spendingStreak} days` : "—"} subtitle={s.spendingStreak > 0 ? "Longest consecutive" : undefined} />
+        <p className="text-xs text-warm-300 mb-1">Transaction frequency and streaks</p>
+        <div className="divide-y divide-cream-200/70">
+          <MetricRow icon={Hash} iconColor="text-warm-600" iconBg="bg-cream-100" label="Transactions" value={s.totalTransactions.toLocaleString()} />
+          <MetricRow icon={CalendarCheck} iconColor="text-blue-500" iconBg="bg-blue-50" label="Active Days" value={`${s.activeDays} / ${s.totalDaysInPeriod}`} subtitle={s.totalDaysInPeriod > 0 ? `${Math.round((s.activeDays / s.totalDaysInPeriod) * 100)}% of days` : undefined} />
+          <MetricRow icon={Flame} iconColor="text-orange-500" iconBg="bg-orange-50" label="Spending Streak" value={s.spendingStreak > 0 ? `${s.spendingStreak} days` : "—"} subtitle={s.spendingStreak > 0 ? "Longest consecutive" : undefined} />
         </div>
       </motion.div>
 
       {/* Category Insights */}
-      <motion.div variants={fadeUp} className="card p-5">
+      <motion.div variants={fadeUp} className="card p-4 sm:p-5">
         <h2 className="font-serif text-lg text-warm-700">Category Insights</h2>
-        <p className="text-xs text-warm-300 mb-4">How you use your categories</p>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <StatItem
-            icon={Tag}
-            iconColor="text-purple-500"
-            iconBg="bg-purple-50"
-            label="Most Used"
-            value={s.mostUsedCategory?.name ?? "—"}
-            subtitle={s.mostUsedCategory ? `${s.mostUsedCategory.count} transactions` : undefined}
-          />
-          <StatItem
-            icon={Crown}
-            iconColor="text-expense"
-            iconBg="bg-expense-light"
-            label="Most Expensive"
-            value={s.mostExpensiveCategory ? fmt(s.mostExpensiveCategory.amount) : "—"}
-            subtitle={s.mostExpensiveCategory?.name}
-          />
-          <StatItem icon={Layers} iconColor="text-warm-500" iconBg="bg-cream-100" label="Categories Used" value={s.categoriesUsed.toLocaleString()} />
+        <p className="text-xs text-warm-300 mb-1">How you use your categories</p>
+        <div className="divide-y divide-cream-200/70">
+          <MetricRow icon={Tag} iconColor="text-purple-500" iconBg="bg-purple-50" label="Most Used" value={s.mostUsedCategory?.name ?? "—"} subtitle={s.mostUsedCategory ? `${s.mostUsedCategory.count} transactions` : undefined} />
+          <MetricRow icon={Crown} iconColor="text-expense" iconBg="bg-expense-light" label="Most Expensive" value={s.mostExpensiveCategory ? fmt(s.mostExpensiveCategory.amount) : "—"} subtitle={s.mostExpensiveCategory?.name} />
+          <MetricRow icon={Layers} iconColor="text-warm-500" iconBg="bg-cream-100" label="Categories Used" value={s.categoriesUsed.toLocaleString()} />
         </div>
       </motion.div>
     </motion.div>


### PR DESCRIPTION
## Summary
Redesigns the Analytics **Stats (Records & Statistics)** and **Health (Financial Health)** tabs so they use space well on mobile instead of leaving large empty gaps. The old layout collapsed every grid to one full-width box per row below 640px, leaving a lonely icon + a wall of dead space per cell.

## Stats tab — *Featured records + list*
The content is two different shapes, so it no longer forces everything into same-size boxes:
- **Top Records** → Biggest Expense & Income as two **featured tiles** (amount + category + date), plus a full-width **"Most Expensive Day" banner**
- **Averages / Activity / Category Insights** → clean **list rows** (icon + label left, value right) with divider lines
- Tighter mobile padding (`p-4 sm:p-5`); long text truncates gracefully

## Health tab
- Overall score → horizontal **gauge + text hero** on mobile (was a tall centered stack) + faint band-colored halo behind the ring
- Sub-scores → **2-up grid** on mobile (5th spans full width) with a **mini progress bar** under each (color-banded `score/100`) and 2-line clamped descriptions

## Preserved
- Privacy masking (`hideAmounts` → `$ ••••••`), empty-period `—` handling
- Tablet/desktop Health grids; data layer, types, API, tab nav, motion variants

## Notes
- The new Stats list design applies at **all widths** (it's a cleaner fit for the content), so desktop no longer shows the 3-box grid either. Easy to scope back to mobile-only if desired.
- **Sparklines were out of scope** — `AnalyticsStatistics` / `HealthSubScore` expose only a single score/value + trend (no time-series); the "graphical" payoff is delivered via progress bars + gauge prominence + trend arrows.

## Test plan
- [ ] Mobile (390px): Stats shows featured tiles + banner + list rows, no dead space
- [ ] Mobile: Health hero is gauge+text side-by-side; sub-scores 2-up with progress bars; 5th full width
- [ ] Toggle **Hide amounts** → monetary values mask; counts/percent/streaks/bars still show
- [ ] Empty period → cards render `—`; progress bars show 0 width without breaking
- [ ] Tablet ≥640px / desktop ≥1024px render cleanly

## Verification
- ✅ `pnpm type-check`
- ✅ `pnpm lint` (No ESLint warnings or errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in two analytics components plus changelog; no API, types, or scoring logic changes.
> 
> **Overview**
> Redesigns the Analytics **Stats** and **Health** tabs so dense metrics read better on small screens, with tighter card padding (`p-4 sm:p-5`) and truncation on long labels.
> 
> On **Records & Statistics**, the old uniform 3-column stat grids are replaced: **Top Records** uses two **featured tiles** (biggest expense/income) plus a full-width **Most Expensive Day** banner; **Averages**, **Activity**, and **Category Insights** use **divider list rows** (`MetricRow`) instead of equal-height boxes. That list layout applies at **all breakpoints**, not only mobile.
> 
> On **Financial Health**, the overall score is a **side-by-side gauge + copy** hero (no stacked centered mobile layout), with a **band-colored halo** on the ring. Sub-scores sit in a **2-column grid** on small screens (consistency spans full width until `sm`), each with an animated **color-banded progress bar** and **2-line clamped** descriptions via new `scoreBarClass`. Privacy masking, empty `—` states, and existing score logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2a61bc3a51fd018d51d4df7b9a24ce036a12f55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Analytics page for mobile with improved Stats tab layout featuring prominent tiles and streamlined list rows
  * Enhanced Health tab with new horizontal gauge design, banded styling, reorganized sub-score grid with progress indicators, and refined visual presentation
  * Desktop and tablet layouts unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->