### PR TITLE
feat(analytics): AI Assessment tab (Gemini report + grounded tips + daily tip)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,8 @@ GEMINI_TIMEOUT_MS="60000"
 # /api/cron/bill-reminders daily on production. Set the same value in the deploy
 # environment and in the repo's Actions secrets.
 CRON_SECRET=""
+
+# Max AI Assessment report generations per user per day (manual generate/refresh).
+# Optional; defaults to 10. The grounded report makes 2 Gemini calls per generation,
+# so this caps cost; cached reports and the daily tip don't count against it.
+AI_ASSESSMENT_DAILY_LIMIT="10"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ src/
 - `EMAIL_FROM` — Sender address (optional; defaults to `Budget Tracker <noreply@resend.dev>` if unset). Use a verified Resend domain in production, e.g. `Budget Tracker <noreply@yourdomain.com>`.
 - `AUTH_URL` — Optional; used in preview/staging deployments
 - `CRON_SECRET` — Shared secret required by `/api/cron/bill-reminders`. Set in the production (Coolify) environment; a Coolify Scheduled Task reuses the same env var to call the endpoint daily (see **Cron Jobs** below).
+- `AI_ASSESSMENT_DAILY_LIMIT` — Optional; max AI Assessment report generations per user per day (default `10`). The grounded report makes 2 Gemini calls per generation; cached reports and the daily tip don't count against it.
 
 ## Cron Jobs
 Production runs on Coolify. Schedules are configured in the Coolify dashboard under **Application > Scheduled Tasks** (not in the repo). Each task runs its command inside the running container, so it can hit the app at `http://localhost:3000` and reuse the container's env vars.
@@ -121,6 +122,7 @@ Active tasks:
 - **Modal** (`src/components/ui/modal.tsx`) — uses `visualViewport` API for keyboard-aware positioning on iOS Safari
 - **Receipt scanning** is opt-in per user — toggled in Profile Settings > Features; uses Gemini AI for OCR and per-category itemization
 - **Receipt itemization** — multi-scan groups transactions by `receiptGroupId`; per-transaction `receiptBreakdown` JSON stores individual line items for each category
+- **AI Assessment** (`src/lib/ai-assessment.ts`) — Gemini turns the analytics page's already-computed `AnalyticsData` into a personalized report; two parallel calls (structured data analysis + grounded web tips via Google Search), cached per period in `AiAssessment`, metered by `AiUsageLog`. Prose is privacy-safe by construction (relative/percentage language, not raw amounts)
 - **TanStack React Query** — all data fetching uses React Query; `queryKeys` object in each query hook scopes cache invalidation; `query-client.ts` exports a factory (needed for server/client separation)
 - **Shared budget queries** (`src/lib/budget-queries.ts`) — dependency-injected Prisma functions shared between API routes and the MCP server
 - **Label schedules** — labels can have time-of-day + day-of-week schedules that auto-tag transactions; pure matching in `schedule-matching.ts`, server helpers in `schedule-server.ts`, client hook in `use-scheduled-label.ts`; first-created label wins on overlap; `labelIds: undefined` = server auto-applies, `labelIds: []` = user opted out
@@ -133,6 +135,9 @@ Active tasks:
 - `GET/POST /api/transactions` — list (filters/pagination/timezone) + create
 - `PUT/DELETE /api/transactions/[id]` — update/delete (ownership check)
 - `GET /api/analytics` — analytics data (income/expenses, category/label breakdowns, cash flow) with granularity, date range, timezone, and type filter params
+- `GET /api/assessment` — cached AI Assessment report for a period (`granularity`/`from`/`to`); returns `{ report | null, generatedAt, model }`
+- `POST /api/assessment/generate` — generate/refresh the AI report for a period (Gemini structured analysis + grounded web tips); caches it and enforces a per-day cap
+- `GET /api/assessment/daily-tip` — today's lightweight AI save/earn tip (lazily generated + cached per local day)
 - `GET /api/dashboard` — aggregated stats, category breakdown, monthly trends
 - `GET/POST /api/categories` — list (defaults + custom) + create
 - `PUT/DELETE /api/categories/[id]` — update/delete (custom only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable development history for the Budget Tracker app.
 
+## 2026-06-15 — AI Assessment tab (Analytics)
+
+### AI-powered financial assessment
+- New **AI Assessment** tab on the Analytics page — Gemini analyzes the selected period's already-computed data and returns a personalized report: Summary + score commentary, **Watch list**, **Cut back** (with est. monthly savings), **Boost savings**, **Ways to earn**, and **Quick actions**
+- **Tips from the web** section uses **Gemini Google Search grounding** (localized to the user's currency/region) with linked sources
+- **Daily tip** card: a lightweight save/earn nudge, lazily generated once per local day and cached
+- **On-demand + cached**: a "Generate / Refresh" button calls the AI; results are cached per period (`granularity:from:to`) so revisits don't re-call. Privacy by construction — prose uses relative/percentage terms; numeric fields respect Hide Amounts
+- Report = two parallel Gemini calls (structured data analysis + grounded web tips); reuses `generateContentWithRetry`/retry/fallback from `src/lib/gemini.ts`
+- New routes: `GET /api/assessment`, `POST /api/assessment/generate`, `GET /api/assessment/daily-tip`
+- New models: `AiAssessment` (cache) + `AiUsageLog` (per-day generation cap, default 10 via `AI_ASSESSMENT_DAILY_LIMIT`); migration `20260615120000_add_ai_assessment`
+- Available to all signed-in users for v1; role/feature gating (like receipt scan) is a future option
+
 ## 2026-06-15 — Analytics Stats & Health mobile redesign
 
 ### Stats (Records & Statistics) tab

--- a/prisma/migrations/20260615120000_add_ai_assessment/migration.sql
+++ b/prisma/migrations/20260615120000_add_ai_assessment/migration.sql
@@ -1,0 +1,42 @@
+-- CreateEnum
+CREATE TYPE "AiInsightKind" AS ENUM ('REPORT', 'DAILY_TIP');
+
+-- CreateTable
+CREATE TABLE "ai_assessments" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "kind" "AiInsightKind" NOT NULL,
+    "period_key" TEXT NOT NULL,
+    "content" JSONB NOT NULL,
+    "sources" JSONB,
+    "model" TEXT NOT NULL,
+    "generated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ai_assessments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ai_usage_logs" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "kind" "AiInsightKind" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ai_usage_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ai_assessments_user_id_idx" ON "ai_assessments"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ai_assessments_user_id_kind_period_key_key" ON "ai_assessments"("user_id", "kind", "period_key");
+
+-- CreateIndex
+CREATE INDEX "ai_usage_logs_user_id_created_at_idx" ON "ai_usage_logs"("user_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "ai_assessments" ADD CONSTRAINT "ai_assessments_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ai_usage_logs" ADD CONSTRAINT "ai_usage_logs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,11 @@ enum TokenType {
   PASSWORD_RESET
 }
 
+enum AiInsightKind {
+  REPORT
+  DAILY_TIP
+}
+
 model User {
   id           String        @id @default(cuid())
   name         String
@@ -68,6 +73,8 @@ model User {
   scheduledTransactions   ScheduledTransaction[]
   verificationTokens      VerificationToken[]
   labels                  Label[]
+  aiAssessments           AiAssessment[]
+  aiUsageLogs             AiUsageLog[]
   createdAt    DateTime      @default(now()) @map("created_at")
   updatedAt    DateTime      @updatedAt @map("updated_at")
 
@@ -136,6 +143,34 @@ model ScanLog {
 
   @@index([userId, createdAt])
   @@map("scan_logs")
+}
+
+model AiAssessment {
+  id          String        @id @default(cuid())
+  userId      String        @map("user_id")
+  user        User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  kind        AiInsightKind
+  periodKey   String        @map("period_key")
+  content     Json
+  sources     Json?
+  model       String
+  generatedAt DateTime      @default(now()) @map("generated_at")
+  createdAt   DateTime      @default(now()) @map("created_at")
+
+  @@unique([userId, kind, periodKey])
+  @@index([userId])
+  @@map("ai_assessments")
+}
+
+model AiUsageLog {
+  id        String        @id @default(cuid())
+  userId    String        @map("user_id")
+  user      User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  kind      AiInsightKind
+  createdAt DateTime      @default(now()) @map("created_at")
+
+  @@index([userId, createdAt])
+  @@map("ai_usage_logs")
 }
 
 model ScheduledTransaction {

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -134,7 +134,13 @@ function AnalyticsTabBar({
   className?: string;
 }) {
   return (
-    <div role="tablist" className={cn("grid grid-cols-2 sm:flex gap-1 p-1 bg-cream-100 rounded-xl", className)}>
+    <div
+      role="tablist"
+      className={cn(
+        "flex w-full gap-1 overflow-x-auto snap-x snap-mandatory scrollbar-hide p-1 bg-cream-100 rounded-xl sm:w-fit sm:overflow-visible",
+        className
+      )}
+    >
       {ANALYTICS_TABS.map((tab) => (
         <button
           key={tab.id}
@@ -142,7 +148,7 @@ function AnalyticsTabBar({
           aria-selected={activeTab === tab.id}
           onClick={() => onSelect(tab.id)}
           className={cn(
-            "relative flex items-center justify-center gap-1.5 px-3 py-2.5 sm:py-1.5 rounded-lg text-sm font-medium transition-colors",
+            "relative flex items-center justify-center gap-1.5 shrink-0 snap-start px-3 py-2.5 sm:py-1.5 rounded-lg text-sm font-medium transition-colors",
             activeTab === tab.id ? "text-warm-700" : "text-warm-400 hover:text-warm-500"
           )}
         >
@@ -153,8 +159,8 @@ function AnalyticsTabBar({
               transition={{ type: "spring", bounce: 0.2, duration: 0.4 }}
             />
           )}
-          <tab.icon className="relative w-4 h-4" />
-          <span className="relative">
+          <tab.icon className="relative w-4 h-4 shrink-0" />
+          <span className="relative whitespace-nowrap">
             <span className="hidden sm:inline">{tab.label}</span>
             <span className="sm:hidden">{tab.shortLabel}</span>
           </span>

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -137,7 +137,7 @@ function AnalyticsTabBar({
     <div
       role="tablist"
       className={cn(
-        "flex w-full gap-1 overflow-x-auto snap-x snap-mandatory scrollbar-hide p-1 bg-cream-100 rounded-xl sm:w-fit sm:overflow-visible",
+        "grid grid-cols-4 w-full gap-1 p-1 bg-cream-100 rounded-xl sm:flex sm:w-fit",
         className
       )}
     >
@@ -148,7 +148,7 @@ function AnalyticsTabBar({
           aria-selected={activeTab === tab.id}
           onClick={() => onSelect(tab.id)}
           className={cn(
-            "relative flex items-center justify-center gap-1.5 shrink-0 snap-start px-3 py-2.5 sm:py-1.5 rounded-lg text-sm font-medium transition-colors",
+            "relative flex items-center justify-center gap-1 sm:gap-1.5 min-w-0 px-2 sm:px-3 py-2.5 sm:py-1.5 rounded-lg text-xs sm:text-sm font-medium transition-colors",
             activeTab === tab.id ? "text-warm-700" : "text-warm-400 hover:text-warm-500"
           )}
         >
@@ -160,7 +160,7 @@ function AnalyticsTabBar({
             />
           )}
           <tab.icon className="relative w-4 h-4 shrink-0" />
-          <span className="relative whitespace-nowrap">
+          <span className="relative truncate">
             <span className="hidden sm:inline">{tab.label}</span>
             <span className="sm:hidden">{tab.shortLabel}</span>
           </span>

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -134,7 +134,7 @@ function AnalyticsTabBar({
   className?: string;
 }) {
   return (
-    <div role="tablist" className={cn("grid grid-cols-3 sm:flex gap-1 p-1 bg-cream-100 rounded-xl", className)}>
+    <div role="tablist" className={cn("grid grid-cols-2 sm:flex gap-1 p-1 bg-cream-100 rounded-xl", className)}>
       {ANALYTICS_TABS.map((tab) => (
         <button
           key={tab.id}

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -11,6 +11,7 @@ import {
   Heart,
   Layers,
   PieChart,
+  Sparkles,
   Tags,
   Trophy,
 } from "lucide-react";
@@ -39,15 +40,17 @@ import { AnalyticsHero } from "@/components/analytics/analytics-hero";
 import { AnalyticsHeroSkeleton, AnalyticsContentSkeleton } from "@/components/analytics/analytics-skeleton";
 import { RecordsStatistics } from "@/components/analytics/records-statistics";
 import { FinancialHealthScore } from "@/components/analytics/financial-health-score";
+import { AiAssessmentReport } from "@/components/analytics/ai-assessment-report";
 import { stagger, fadeUp } from "@/components/analytics/motion-variants";
 import type { AnalyticsTypeFilter } from "@/types";
 
-type AnalyticsTab = "reports" | "statistics" | "health";
+type AnalyticsTab = "reports" | "statistics" | "health" | "ai-assessment";
 
 const ANALYTICS_TABS = [
   { id: "reports" as const, label: "Reports", shortLabel: "Reports", icon: BarChart3 },
   { id: "statistics" as const, label: "Records & Statistics", shortLabel: "Stats", icon: Trophy },
   { id: "health" as const, label: "Financial Health", shortLabel: "Health", icon: Heart },
+  { id: "ai-assessment" as const, label: "AI Assessment", shortLabel: "AI", icon: Sparkles },
 ];
 
 /**
@@ -453,6 +456,18 @@ export default function AnalyticsPage() {
           {activeTab === "health" && (
             <motion.div key="health" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}>
               <FinancialHealthScore healthScore={data.healthScore} />
+            </motion.div>
+          )}
+
+          {/* AI Assessment Tab */}
+          {activeTab === "ai-assessment" && (
+            <motion.div key="ai-assessment" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}>
+              <AiAssessmentReport
+                data={data}
+                period={{ granularity: params.granularity, from: params.from, to: params.to }}
+                currency={currency}
+                hideAmounts={hideAmounts}
+              />
             </motion.div>
           )}
         </>

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -8,6 +8,7 @@ import { UserProvider } from "@/components/user-provider";
 import { AppShell } from "@/components/app-shell";
 import { BillReminderProvider } from "@/components/bills/bill-reminder-provider";
 import { ToastProvider } from "@/components/ui/toast";
+import { AssessmentProvider } from "@/components/assessment-provider";
 
 export default async function AppLayout({
   children,
@@ -91,9 +92,11 @@ export default async function AppLayout({
       >
         <PrivacyProvider>
           <ToastProvider>
-            <BillReminderProvider>
-              <AppShell>{children}</AppShell>
-            </BillReminderProvider>
+            <AssessmentProvider>
+              <BillReminderProvider>
+                <AppShell>{children}</AppShell>
+              </BillReminderProvider>
+            </AssessmentProvider>
           </ToastProvider>
         </PrivacyProvider>
       </UserProvider>

--- a/src/app/api/assessment/daily-tip/route.ts
+++ b/src/app/api/assessment/daily-tip/route.ts
@@ -62,25 +62,21 @@ export async function GET() {
       upcomingBills: bills,
     };
 
-    const { tip } = await generateDailyTip(input);
+    const { tip, model } = await generateDailyTip(input);
 
+    const content = tip as unknown as Prisma.InputJsonValue;
     const row = await prisma.aiAssessment.upsert({
       where: { userId_kind_periodKey: { userId, kind: "DAILY_TIP", periodKey } },
-      create: {
-        userId,
-        kind: "DAILY_TIP",
-        periodKey,
-        content: tip as unknown as Prisma.InputJsonValue,
-        model: process.env.GEMINI_MODEL ?? "gemini-2.5-flash",
-      },
-      update: { content: tip as unknown as Prisma.InputJsonValue, generatedAt: new Date() },
+      create: { userId, kind: "DAILY_TIP", periodKey, content, model },
+      update: { content, model, generatedAt: new Date() },
     });
     await prisma.aiUsageLog.create({ data: { userId, kind: "DAILY_TIP" } });
 
     const body: AiDailyTipResponse = { tip, generatedAt: row.generatedAt.toISOString() };
     return NextResponse.json(body);
-  } catch {
-    // Non-blocking: the daily tip is a nicety — degrade silently to "no tip".
+  } catch (error) {
+    // Non-blocking: the daily tip is a nicety — degrade to "no tip", but log so failures are visible.
+    console.error("[assessment/daily-tip] failed:", error instanceof Error ? error.message : error);
     const body: AiDailyTipResponse = { tip: null, generatedAt: null };
     return NextResponse.json(body);
   }

--- a/src/app/api/assessment/daily-tip/route.ts
+++ b/src/app/api/assessment/daily-tip/route.ts
@@ -44,7 +44,7 @@ export async function GET() {
     const [overview, spending, billsResult] = await Promise.all([
       getBudgetOverview(prisma, userId, { month: monthStr }),
       getSpendingByCategory(prisma, userId, { month: monthStr }),
-      getUpcomingBills(prisma, userId, { days: 14 }),
+      getUpcomingBills(prisma, userId, { days: 14, timezoneOffset: user.timezoneOffset }),
     ]);
 
     const bills: UpcomingBillsContext = {

--- a/src/app/api/assessment/daily-tip/route.ts
+++ b/src/app/api/assessment/daily-tip/route.ts
@@ -70,7 +70,11 @@ export async function GET() {
       create: { userId, kind: "DAILY_TIP", periodKey, content, model },
       update: { content, model, generatedAt: new Date() },
     });
-    await prisma.aiUsageLog.create({ data: { userId, kind: "DAILY_TIP" } });
+    // Best-effort metering — must not blank the already-saved tip (which would then be
+    // cached empty for the rest of the local day) if this write fails.
+    await prisma.aiUsageLog
+      .create({ data: { userId, kind: "DAILY_TIP" } })
+      .catch((e) => console.error("[assessment/daily-tip] usage log failed:", e instanceof Error ? e.message : e));
 
     const body: AiDailyTipResponse = { tip, generatedAt: row.generatedAt.toISOString() };
     return NextResponse.json(body);

--- a/src/app/api/assessment/daily-tip/route.ts
+++ b/src/app/api/assessment/daily-tip/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { getAuthUserId } from "@/lib/session";
+import { getBudgetOverview, getSpendingByCategory, getUpcomingBills } from "@/lib/budget-queries";
+import { generateDailyTip, type DailyTipInput, type UpcomingBillsContext } from "@/lib/ai-assessment";
+import type { AiDailyTip, AiDailyTipResponse } from "@/types";
+
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+/** GET /api/assessment/daily-tip — today's tip (cached per local day; lazily generated). */
+export async function GET() {
+  const userId = await getAuthUserId();
+  if (userId instanceof NextResponse) return userId;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { currency: true, timezoneOffset: true },
+  });
+  if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
+
+  // Local "today" using the user's stored timezone offset (minutes).
+  const localNow = new Date(Date.now() - user.timezoneOffset * 60_000);
+  const localDate = localNow.toISOString().slice(0, 10); // YYYY-MM-DD
+  const monthStr = localDate.slice(0, 7); // YYYY-MM
+  const monthLabel = `${MONTHS[localNow.getUTCMonth()]} ${localNow.getUTCFullYear()}`;
+  const periodKey = `daily:${localDate}`;
+
+  const cached = await prisma.aiAssessment.findUnique({
+    where: { userId_kind_periodKey: { userId, kind: "DAILY_TIP", periodKey } },
+  });
+  if (cached) {
+    const body: AiDailyTipResponse = {
+      tip: cached.content as unknown as AiDailyTip,
+      generatedAt: cached.generatedAt.toISOString(),
+    };
+    return NextResponse.json(body);
+  }
+
+  try {
+    const [overview, spending, billsResult] = await Promise.all([
+      getBudgetOverview(prisma, userId, { month: monthStr }),
+      getSpendingByCategory(prisma, userId, { month: monthStr }),
+      getUpcomingBills(prisma, userId, { days: 14 }),
+    ]);
+
+    const bills: UpcomingBillsContext = {
+      count: billsResult.count,
+      totalAmount: billsResult.totalAmount,
+      bills: billsResult.bills,
+    };
+    const input: DailyTipInput = {
+      currency: user.currency,
+      monthLabel,
+      income: overview.totalIncome,
+      expenses: overview.totalExpenses,
+      net: overview.net,
+      topCategories: spending.slice(0, 6).map((c) => ({ name: c.name, amount: c.amount, pct: c.percentage })),
+      upcomingBills: bills,
+    };
+
+    const { tip } = await generateDailyTip(input);
+
+    const row = await prisma.aiAssessment.upsert({
+      where: { userId_kind_periodKey: { userId, kind: "DAILY_TIP", periodKey } },
+      create: {
+        userId,
+        kind: "DAILY_TIP",
+        periodKey,
+        content: tip as unknown as Prisma.InputJsonValue,
+        model: process.env.GEMINI_MODEL ?? "gemini-2.5-flash",
+      },
+      update: { content: tip as unknown as Prisma.InputJsonValue, generatedAt: new Date() },
+    });
+    await prisma.aiUsageLog.create({ data: { userId, kind: "DAILY_TIP" } });
+
+    const body: AiDailyTipResponse = { tip, generatedAt: row.generatedAt.toISOString() };
+    return NextResponse.json(body);
+  } catch {
+    // Non-blocking: the daily tip is a nicety — degrade silently to "no tip".
+    const body: AiDailyTipResponse = { tip: null, generatedAt: null };
+    return NextResponse.json(body);
+  }
+}

--- a/src/app/api/assessment/generate/route.ts
+++ b/src/app/api/assessment/generate/route.ts
@@ -66,7 +66,7 @@ export async function POST(request: Request) {
   const usageLog = await prisma.aiUsageLog.create({ data: { userId, kind: "REPORT" } });
 
   try {
-    const billsResult = await getUpcomingBills(prisma, userId, { days: 14 });
+    const billsResult = await getUpcomingBills(prisma, userId, { days: 14, timezoneOffset: tzOffset });
     const bills: UpcomingBillsContext = {
       count: billsResult.count,
       totalAmount: billsResult.totalAmount,

--- a/src/app/api/assessment/generate/route.ts
+++ b/src/app/api/assessment/generate/route.ts
@@ -87,6 +87,7 @@ export async function POST(request: Request) {
         { status: 503 }
       );
     }
+    console.error("[assessment/generate] failed:", error instanceof Error ? error.message : error);
     return NextResponse.json(
       { error: "Failed to generate assessment. Please try again." },
       { status: 500 }

--- a/src/app/api/assessment/generate/route.ts
+++ b/src/app/api/assessment/generate/route.ts
@@ -29,7 +29,8 @@ export async function POST(request: Request) {
   let json: unknown;
   try {
     json = await request.json();
-  } catch {
+  } catch (error) {
+    console.error("[assessment/generate] invalid JSON body:", error instanceof Error ? error.message : error);
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
 

--- a/src/app/api/assessment/generate/route.ts
+++ b/src/app/api/assessment/generate/route.ts
@@ -91,7 +91,10 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     // Generation failed — release the reserved quota so the user isn't charged for it.
-    await prisma.aiUsageLog.delete({ where: { id: usageLog.id } }).catch(() => {});
+    // Log if the rollback itself fails (the row would otherwise stay counted toward the cap).
+    await prisma.aiUsageLog
+      .delete({ where: { id: usageLog.id } })
+      .catch((e) => console.error("[assessment/generate] quota rollback failed:", e instanceof Error ? e.message : e));
 
     if (isGeminiUnavailable(error)) {
       return NextResponse.json(

--- a/src/app/api/assessment/generate/route.ts
+++ b/src/app/api/assessment/generate/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { getAuthUserId } from "@/lib/session";
+import { isGeminiUnavailable } from "@/lib/gemini";
+import { getUpcomingBills } from "@/lib/budget-queries";
+import {
+  assessmentPayloadSchema,
+  generateAssessment,
+  type UpcomingBillsContext,
+} from "@/lib/ai-assessment";
+
+/** Max AI report generations per user per day (manual generate/refresh). Override with AI_ASSESSMENT_DAILY_LIMIT. */
+const parsedLimit = Number.parseInt(process.env.AI_ASSESSMENT_DAILY_LIMIT ?? "", 10);
+const DAILY_LIMIT = Number.isNaN(parsedLimit) ? 10 : parsedLimit;
+
+const generateRequestSchema = z.object({
+  from: z.string().min(1),
+  to: z.string().min(1),
+  payload: assessmentPayloadSchema,
+});
+
+/** POST /api/assessment/generate — generate (or refresh) the report for a period and cache it. */
+export async function POST(request: Request) {
+  const userId = await getAuthUserId();
+  if (userId instanceof NextResponse) return userId;
+
+  let json: unknown;
+  try {
+    json = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const parsed = generateRequestSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+  const { from, to, payload } = parsed.data;
+
+  // Daily generation cap
+  const startOfDay = new Date();
+  startOfDay.setHours(0, 0, 0, 0);
+  const usedToday = await prisma.aiUsageLog.count({
+    where: { userId, kind: "REPORT", createdAt: { gte: startOfDay } },
+  });
+  if (usedToday >= DAILY_LIMIT) {
+    return NextResponse.json(
+      { error: "Daily AI generation limit reached. Please try again tomorrow." },
+      { status: 429 }
+    );
+  }
+
+  const periodKey = `${payload.granularity}:${from}:${to}`;
+
+  try {
+    const billsResult = await getUpcomingBills(prisma, userId, { days: 14 });
+    const bills: UpcomingBillsContext = {
+      count: billsResult.count,
+      totalAmount: billsResult.totalAmount,
+      bills: billsResult.bills,
+    };
+
+    const { report, sources, model } = await generateAssessment(payload, bills);
+
+    const content = report as unknown as Prisma.InputJsonValue;
+    const sourcesJson = sources as unknown as Prisma.InputJsonValue;
+
+    const row = await prisma.aiAssessment.upsert({
+      where: { userId_kind_periodKey: { userId, kind: "REPORT", periodKey } },
+      create: { userId, kind: "REPORT", periodKey, content, sources: sourcesJson, model },
+      update: { content, sources: sourcesJson, model, generatedAt: new Date() },
+    });
+
+    await prisma.aiUsageLog.create({ data: { userId, kind: "REPORT" } });
+
+    return NextResponse.json({
+      report,
+      generatedAt: row.generatedAt.toISOString(),
+      model,
+    });
+  } catch (error) {
+    if (isGeminiUnavailable(error)) {
+      return NextResponse.json(
+        { error: "The AI service is busy right now. Please try again in a minute." },
+        { status: 503 }
+      );
+    }
+    return NextResponse.json(
+      { error: "Failed to generate assessment. Please try again." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/assessment/generate/route.ts
+++ b/src/app/api/assessment/generate/route.ts
@@ -58,6 +58,12 @@ export async function POST(request: Request) {
 
   const periodKey = `${payload.granularity}:${from}:${to}`;
 
+  // Reserve quota BEFORE the expensive Gemini calls (mirrors the bill-reminders
+  // log-then-delete-on-failure pattern). This shrinks the cap race window from the
+  // full ~10s generation to the few ms between the count() above and this write,
+  // so concurrent requests can't each run two Gemini calls. Rolled back on failure.
+  const usageLog = await prisma.aiUsageLog.create({ data: { userId, kind: "REPORT" } });
+
   try {
     const billsResult = await getUpcomingBills(prisma, userId, { days: 14 });
     const bills: UpcomingBillsContext = {
@@ -77,14 +83,15 @@ export async function POST(request: Request) {
       update: { content, sources: sourcesJson, model, generatedAt: new Date() },
     });
 
-    await prisma.aiUsageLog.create({ data: { userId, kind: "REPORT" } });
-
     return NextResponse.json({
       report,
       generatedAt: row.generatedAt.toISOString(),
       model,
     });
   } catch (error) {
+    // Generation failed — release the reserved quota so the user isn't charged for it.
+    await prisma.aiUsageLog.delete({ where: { id: usageLog.id } }).catch(() => {});
+
     if (isGeminiUnavailable(error)) {
       return NextResponse.json(
         { error: "The AI service is busy right now. Please try again in a minute." },

--- a/src/app/api/assessment/generate/route.ts
+++ b/src/app/api/assessment/generate/route.ts
@@ -39,9 +39,13 @@ export async function POST(request: Request) {
   }
   const { from, to, payload } = parsed.data;
 
-  // Daily generation cap
-  const startOfDay = new Date();
-  startOfDay.setHours(0, 0, 0, 0);
+  // Daily generation cap — anchored to the user's local midnight, not the server's.
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { timezoneOffset: true } });
+  const tzOffset = user?.timezoneOffset ?? 0;
+  const localNow = new Date(Date.now() - tzOffset * 60_000);
+  const startOfDay = new Date(
+    Date.UTC(localNow.getUTCFullYear(), localNow.getUTCMonth(), localNow.getUTCDate()) + tzOffset * 60_000
+  );
   const usedToday = await prisma.aiUsageLog.count({
     where: { userId, kind: "REPORT", createdAt: { gte: startOfDay } },
   });

--- a/src/app/api/assessment/route.ts
+++ b/src/app/api/assessment/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthUserId } from "@/lib/session";
+import type { AiAssessmentReport, AiAssessmentResponse } from "@/types";
+
+/** GET /api/assessment?granularity&from&to — returns the cached report for the period (or null). */
+export async function GET(request: Request) {
+  const userId = await getAuthUserId();
+  if (userId instanceof NextResponse) return userId;
+
+  const { searchParams } = new URL(request.url);
+  const granularity = searchParams.get("granularity");
+  const from = searchParams.get("from");
+  const to = searchParams.get("to");
+  if (!granularity || !from || !to) {
+    return NextResponse.json({ error: "Missing period params" }, { status: 400 });
+  }
+
+  const periodKey = `${granularity}:${from}:${to}`;
+  const row = await prisma.aiAssessment.findUnique({
+    where: { userId_kind_periodKey: { userId, kind: "REPORT", periodKey } },
+  });
+
+  const body: AiAssessmentResponse = row
+    ? {
+        report: row.content as unknown as AiAssessmentReport,
+        generatedAt: row.generatedAt.toISOString(),
+        model: row.model,
+      }
+    : { report: null, generatedAt: null, model: null };
+
+  return NextResponse.json(body);
+}

--- a/src/components/analytics/ai-assessment-report.tsx
+++ b/src/components/analytics/ai-assessment-report.tsx
@@ -70,7 +70,6 @@ const buildPayload = (data: AnalyticsData, currency: string, granularity: string
     categoryBreakdown: data.allCategoryBreakdown.map((c) => ({
       name: c.name, type: c.type, amount: c.amount, percentage: c.percentage, transactionCount: c.transactionCount,
     })),
-    labelBreakdown: data.labelBreakdown.map((l) => ({ name: l.name, amount: l.amount, percentage: l.percentage })),
     statistics: {
       avgDailySpend: data.statistics.avgDailySpend,
       avgExpenseSize: data.statistics.avgExpenseSize,
@@ -86,9 +85,6 @@ const buildPayload = (data: AnalyticsData, currency: string, granularity: string
         ? { name: data.statistics.mostExpensiveCategory.name, amount: data.statistics.mostExpensiveCategory.amount }
         : null,
     },
-    topTransactions: data.topTransactions.map((t) => ({
-      description: t.description, amount: t.amount, type: t.type, categoryName: t.categoryName, dateLabel: t.dateLabel,
-    })),
   };
 };
 

--- a/src/components/analytics/ai-assessment-report.tsx
+++ b/src/components/analytics/ai-assessment-report.tsx
@@ -123,7 +123,7 @@ function DailyTipCard() {
 }
 
 export function AiAssessmentReport({ data, period, currency, hideAmounts }: AiAssessmentReportProps) {
-  const { data: reportData, isLoading } = useAssessmentQuery(period);
+  const { data: reportData, isLoading, isError: reportError } = useAssessmentQuery(period);
   const { isGenerating, generate } = useAssessment();
 
   const payload = useMemo(() => buildPayload(data, currency, period.granularity), [data, currency, period.granularity]);
@@ -177,6 +177,10 @@ export function AiAssessmentReport({ data, period, currency, hideAmounts }: AiAs
           <p className="text-xs text-warm-400 mt-3">
             Analyzing in the background — feel free to browse; we&apos;ll notify you when it&apos;s ready.
           </p>
+        )}
+
+        {reportError && !pending && (
+          <p className="text-xs text-expense mt-3">Couldn&apos;t load your saved assessment. Tap Generate to try again.</p>
         )}
 
         {!hasData && (

--- a/src/components/analytics/ai-assessment-report.tsx
+++ b/src/components/analytics/ai-assessment-report.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useMemo } from "react";
+import { motion } from "framer-motion";
+import {
+  Sparkles,
+  RefreshCw,
+  AlertTriangle,
+  Scissors,
+  PiggyBank,
+  Lightbulb,
+  CheckCircle2,
+  Globe,
+  ExternalLink,
+  Loader2,
+} from "lucide-react";
+import { cn, formatCurrency } from "@/lib/utils";
+import { stagger, fadeUp } from "@/components/analytics/motion-variants";
+import {
+  useAssessmentQuery,
+  useGenerateAssessment,
+  useDailyTipQuery,
+} from "@/hooks/use-assessment";
+import type { AnalyticsData, AiWatchSeverity } from "@/types";
+import type { AssessmentPayload } from "@/lib/ai-assessment";
+
+interface AiAssessmentReportProps {
+  data: AnalyticsData;
+  period: { granularity: string; from: string; to: string };
+  currency: string;
+  hideAmounts: boolean;
+}
+
+const SEVERITY_STYLES: Record<AiWatchSeverity, { dot: string; label: string; text: string }> = {
+  high: { dot: "bg-expense", label: "High", text: "text-expense" },
+  medium: { dot: "bg-amber", label: "Medium", text: "text-amber-dark" },
+  low: { dot: "bg-warm-400", label: "Low", text: "text-warm-400" },
+};
+
+const relativeTime = (iso: string): string => {
+  const mins = Math.round((Date.now() - new Date(iso).getTime()) / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+};
+
+/** Build the AI payload from the already-computed analytics data. */
+const buildPayload = (data: AnalyticsData, currency: string, granularity: string): AssessmentPayload => {
+  const sub = data.healthScore.subScores;
+  const pick = (s: { score: number; label: string; trend: string }) => ({ score: s.score, label: s.label, trend: s.trend });
+  return {
+    currency,
+    granularity: granularity as AssessmentPayload["granularity"],
+    periodLabel: data.periodLabel,
+    previousPeriodLabel: data.previousPeriodLabel,
+    summary: data.summary,
+    previousSummary: data.previousSummary,
+    healthScore: {
+      overallScore: data.healthScore.overallScore,
+      overallLabel: data.healthScore.overallLabel,
+      overallTrend: data.healthScore.overallTrend,
+      savingsRate: data.healthScore.savingsRate,
+      subScores: {
+        savingsRate: pick(sub.savingsRate),
+        expenseTrend: pick(sub.expenseTrend),
+        incomeStability: pick(sub.incomeStability),
+        diversification: pick(sub.diversification),
+        consistency: pick(sub.consistency),
+      },
+    },
+    categoryBreakdown: data.allCategoryBreakdown.map((c) => ({
+      name: c.name, type: c.type, amount: c.amount, percentage: c.percentage, transactionCount: c.transactionCount,
+    })),
+    labelBreakdown: data.labelBreakdown.map((l) => ({ name: l.name, amount: l.amount, percentage: l.percentage })),
+    statistics: {
+      avgDailySpend: data.statistics.avgDailySpend,
+      avgExpenseSize: data.statistics.avgExpenseSize,
+      spendingStreak: data.statistics.spendingStreak,
+      activeDays: data.statistics.activeDays,
+      totalDaysInPeriod: data.statistics.totalDaysInPeriod,
+      totalTransactions: data.statistics.totalTransactions,
+      categoriesUsed: data.statistics.categoriesUsed,
+      mostUsedCategory: data.statistics.mostUsedCategory
+        ? { name: data.statistics.mostUsedCategory.name, count: data.statistics.mostUsedCategory.count }
+        : null,
+      mostExpensiveCategory: data.statistics.mostExpensiveCategory
+        ? { name: data.statistics.mostExpensiveCategory.name, amount: data.statistics.mostExpensiveCategory.amount }
+        : null,
+    },
+    topTransactions: data.topTransactions.map((t) => ({
+      description: t.description, amount: t.amount, type: t.type, categoryName: t.categoryName, dateLabel: t.dateLabel,
+    })),
+  };
+};
+
+function Section({ icon: Icon, title, children }: { icon: typeof Sparkles; title: string; children: React.ReactNode }) {
+  return (
+    <motion.div variants={fadeUp} className="card p-4 sm:p-5">
+      <div className="flex items-center gap-2 mb-3">
+        <Icon className="w-4 h-4 text-amber" />
+        <h3 className="font-serif text-lg text-warm-700">{title}</h3>
+      </div>
+      {children}
+    </motion.div>
+  );
+}
+
+function DailyTipCard() {
+  const { data, isLoading } = useDailyTipQuery();
+  if (isLoading) {
+    return <div className="card p-4 sm:p-5 animate-pulse h-20 bg-cream-50/60" />;
+  }
+  if (!data?.tip) return null;
+  return (
+    <motion.div variants={fadeUp} className="card p-4 sm:p-5 bg-amber-light/40 border-amber/20">
+      <div className="flex items-center gap-2 mb-1.5">
+        <Sparkles className="w-4 h-4 text-amber-dark" />
+        <h3 className="text-[11px] font-medium tracking-wider text-amber-dark uppercase">Today&apos;s Tip</h3>
+      </div>
+      <p className="text-sm font-medium text-warm-700">{data.tip.tip}</p>
+      <p className="text-xs text-warm-400 mt-1">{data.tip.rationale}</p>
+    </motion.div>
+  );
+}
+
+export function AiAssessmentReport({ data, period, currency, hideAmounts }: AiAssessmentReportProps) {
+  const { data: reportData, isLoading } = useAssessmentQuery(period);
+  const generate = useGenerateAssessment();
+
+  const payload = useMemo(() => buildPayload(data, currency, period.granularity), [data, currency, period.granularity]);
+  const fmt = (n: number | null) => (n === null ? "—" : hideAmounts ? "•••" : formatCurrency(n, currency));
+
+  const report = reportData?.report;
+  const hasData = data.summary.transactionCount > 0;
+
+  const handleGenerate = () => generate.mutate({ from: period.from, to: period.to, payload });
+
+  return (
+    <motion.div variants={stagger} initial="hidden" animate="show" className="space-y-4">
+      <DailyTipCard />
+
+      {/* Header + generate/refresh */}
+      <motion.div variants={fadeUp} className="card p-4 sm:p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <Sparkles className="w-5 h-5 text-amber" />
+              <h2 className="font-serif text-lg text-warm-700">AI Assessment</h2>
+            </div>
+            <p className="text-xs text-warm-400 mt-1">
+              {report
+                ? `For ${data.periodLabel}${reportData?.generatedAt ? ` · updated ${relativeTime(reportData.generatedAt)}` : ""}`
+                : `Personalized insights for ${data.periodLabel}`}
+            </p>
+          </div>
+          {hasData && (
+            <button
+              type="button"
+              onClick={handleGenerate}
+              disabled={generate.isPending}
+              className="inline-flex items-center gap-2 bg-amber hover:bg-amber-dark text-white font-medium text-sm px-4 py-2 rounded-xl transition-colors shadow-soft disabled:opacity-60 shrink-0"
+            >
+              {generate.isPending ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : report ? (
+                <RefreshCw className="w-4 h-4" />
+              ) : (
+                <Sparkles className="w-4 h-4" />
+              )}
+              {generate.isPending ? "Analyzing…" : report ? "Refresh" : "Generate"}
+            </button>
+          )}
+        </div>
+
+        {generate.isError && (
+          <p className="text-xs text-expense mt-3">{(generate.error as Error).message}</p>
+        )}
+
+        {!hasData && (
+          <p className="text-sm text-warm-400 mt-3">Add some transactions for this period to get an AI assessment.</p>
+        )}
+
+        {hasData && !report && !generate.isPending && !isLoading && (
+          <p className="text-sm text-warm-500 mt-3">
+            Tap <span className="font-medium">Generate</span> to have AI analyze your spending and suggest where to cut back, how to save more, and ways to earn.
+          </p>
+        )}
+      </motion.div>
+
+      {report && (
+        <>
+          {/* Summary + score commentary */}
+          <Section icon={Sparkles} title="Summary">
+            <p className="text-sm text-warm-600 leading-relaxed">{report.summary}</p>
+            <p className="text-sm text-warm-500 leading-relaxed mt-3">{report.scoreCommentary}</p>
+          </Section>
+
+          {report.watchList.length > 0 && (
+            <Section icon={AlertTriangle} title="Watch list">
+              <ul className="space-y-3">
+                {report.watchList.map((item, i) => {
+                  const sev = SEVERITY_STYLES[item.severity];
+                  return (
+                    <li key={i} className="flex gap-3">
+                      <span className={cn("mt-1.5 w-2 h-2 rounded-full shrink-0", sev.dot)} />
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-warm-700">
+                          {item.title} <span className={cn("text-[10px] uppercase tracking-wider", sev.text)}>· {sev.label}</span>
+                        </p>
+                        <p className="text-sm text-warm-500">{item.detail}</p>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Section>
+          )}
+
+          {report.cutBack.length > 0 && (
+            <Section icon={Scissors} title="Cut back">
+              <ul className="space-y-3">
+                {report.cutBack.map((item, i) => (
+                  <li key={i} className="p-3 rounded-xl bg-cream-50/60">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-sm font-medium text-warm-700 truncate">{item.title}</p>
+                      {item.estimatedMonthlySaving !== null && (
+                        <span className="text-xs font-medium text-income shrink-0">save ~{fmt(item.estimatedMonthlySaving)}/mo</span>
+                      )}
+                    </div>
+                    <p className="text-sm text-warm-500 mt-1">{item.reason}</p>
+                    <p className="text-sm text-warm-600 mt-1">💡 {item.suggestion}</p>
+                  </li>
+                ))}
+              </ul>
+            </Section>
+          )}
+
+          {report.boostSavings.length > 0 && (
+            <Section icon={PiggyBank} title="Boost savings">
+              <TipList items={report.boostSavings} />
+            </Section>
+          )}
+
+          {report.earnIdeas.length > 0 && (
+            <Section icon={Lightbulb} title="Ways to earn">
+              <TipList items={report.earnIdeas} />
+            </Section>
+          )}
+
+          {report.quickActions.length > 0 && (
+            <Section icon={CheckCircle2} title="Quick actions">
+              <ul className="space-y-2">
+                {report.quickActions.map((action, i) => (
+                  <li key={i} className="flex gap-2.5 text-sm text-warm-600">
+                    <CheckCircle2 className="w-4 h-4 text-income shrink-0 mt-0.5" />
+                    <span>{action}</span>
+                  </li>
+                ))}
+              </ul>
+            </Section>
+          )}
+
+          {report.webTips.length > 0 && (
+            <Section icon={Globe} title="Tips from the web">
+              <TipList items={report.webTips} />
+              {report.sources.length > 0 && (
+                <div className="mt-4 pt-3 border-t border-cream-200/70">
+                  <p className="text-[10px] font-medium tracking-wider text-warm-400 uppercase mb-2">Sources</p>
+                  <ul className="space-y-1.5">
+                    {report.sources.map((s, i) => (
+                      <li key={i}>
+                        <a
+                          href={s.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 text-xs text-amber-dark hover:underline"
+                        >
+                          <ExternalLink className="w-3 h-3 shrink-0" />
+                          <span className="truncate">{s.title}</span>
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </Section>
+          )}
+
+          <p className="text-[11px] text-warm-300 text-center px-4">
+            AI-generated guidance based on your data — not professional financial advice.
+          </p>
+        </>
+      )}
+    </motion.div>
+  );
+}
+
+function TipList({ items }: { items: Array<{ title: string; detail: string }> }) {
+  return (
+    <ul className="space-y-3">
+      {items.map((item, i) => (
+        <li key={i}>
+          <p className="text-sm font-medium text-warm-700">{item.title}</p>
+          <p className="text-sm text-warm-500">{item.detail}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/analytics/ai-assessment-report.tsx
+++ b/src/components/analytics/ai-assessment-report.tsx
@@ -286,9 +286,9 @@ export function AiAssessmentReport({ data, period, currency, hideAmounts }: AiAs
             </Section>
           )}
 
-          {report.webTips.length > 0 && (
+          {(report.webTips.length > 0 || report.sources.length > 0) && (
             <Section icon={Globe} title="Tips from the web">
-              <TipList items={report.webTips} />
+              {report.webTips.length > 0 && <TipList items={report.webTips} />}
               {report.sources.length > 0 && (
                 <div className="mt-4 pt-3 border-t border-cream-200/70">
                   <p className="text-[10px] font-medium tracking-wider text-warm-400 uppercase mb-2">Sources</p>

--- a/src/components/analytics/ai-assessment-report.tsx
+++ b/src/components/analytics/ai-assessment-report.tsx
@@ -43,6 +43,13 @@ const relativeTime = (iso: string): string => {
   return `${Math.round(hrs / 24)}d ago`;
 };
 
+/** Masks currency amounts (e.g. "₱1,200", "PHP 500", "$50.25") in AI prose so a
+ *  non-compliant model response can't leak figures when Hide Amounts is on.
+ *  Leaves percentages and bare counts intact. */
+const CURRENCY_IN_PROSE = /(?:[₱$€£¥]|\b(?:PHP|USD|EUR|GBP|AUD|CAD|SGD|INR|JPY))\s?\d[\d,]*(?:\.\d+)?/gi;
+const maskProse = (text: string, hide: boolean): string =>
+  hide ? text.replace(CURRENCY_IN_PROSE, "•••") : text;
+
 /** Build the AI payload from the already-computed analytics data. */
 const buildPayload = (data: AnalyticsData, currency: string, granularity: string): AssessmentPayload => {
   const sub = data.healthScore.subScores;
@@ -100,7 +107,7 @@ function Section({ icon: Icon, title, children }: { icon: typeof Sparkles; title
   );
 }
 
-function DailyTipCard() {
+function DailyTipCard({ hideAmounts }: { hideAmounts: boolean }) {
   const { data, isLoading } = useDailyTipQuery();
   if (isLoading) {
     return <div className="card p-4 sm:p-5 animate-pulse h-20 bg-cream-50/60" />;
@@ -112,8 +119,8 @@ function DailyTipCard() {
         <Sparkles className="w-4 h-4 text-amber-dark" />
         <h3 className="text-[11px] font-medium tracking-wider text-amber-dark uppercase">Today&apos;s Tip</h3>
       </div>
-      <p className="text-sm font-medium text-warm-700">{data.tip.tip}</p>
-      <p className="text-xs text-warm-400 mt-1">{data.tip.rationale}</p>
+      <p className="text-sm font-medium text-warm-700">{maskProse(data.tip.tip, hideAmounts)}</p>
+      <p className="text-xs text-warm-400 mt-1">{maskProse(data.tip.rationale, hideAmounts)}</p>
     </motion.div>
   );
 }
@@ -125,7 +132,23 @@ export function AiAssessmentReport({ data, period, currency, hideAmounts }: AiAs
   const payload = useMemo(() => buildPayload(data, currency, period.granularity), [data, currency, period.granularity]);
   const fmt = (n: number | null) => (n === null ? "—" : hideAmounts ? "•••" : formatCurrency(n, currency));
 
-  const report = reportData?.report;
+  const rawReport = reportData?.report;
+  // Mask any currency figures the model may have written into prose when Hide Amounts is on.
+  const report = useMemo(() => {
+    if (!rawReport || !hideAmounts) return rawReport;
+    const m = (s: string) => maskProse(s, true);
+    return {
+      ...rawReport,
+      summary: m(rawReport.summary),
+      scoreCommentary: m(rawReport.scoreCommentary),
+      watchList: rawReport.watchList.map((w) => ({ ...w, title: m(w.title), detail: m(w.detail) })),
+      cutBack: rawReport.cutBack.map((c) => ({ ...c, title: m(c.title), reason: m(c.reason), suggestion: m(c.suggestion) })),
+      boostSavings: rawReport.boostSavings.map((t) => ({ ...t, title: m(t.title), detail: m(t.detail) })),
+      earnIdeas: rawReport.earnIdeas.map((t) => ({ ...t, title: m(t.title), detail: m(t.detail) })),
+      quickActions: rawReport.quickActions.map(m),
+      webTips: rawReport.webTips.map((t) => ({ ...t, title: m(t.title), detail: m(t.detail) })),
+    };
+  }, [rawReport, hideAmounts]);
   const hasData = data.summary.transactionCount > 0;
   const pending = isGenerating(periodKeyOf(period.granularity, period.from, period.to));
 
@@ -134,7 +157,7 @@ export function AiAssessmentReport({ data, period, currency, hideAmounts }: AiAs
 
   return (
     <motion.div variants={stagger} initial="hidden" animate="show" className="space-y-4">
-      <DailyTipCard />
+      <DailyTipCard hideAmounts={hideAmounts} />
 
       {/* Header + generate/refresh */}
       <motion.div variants={fadeUp} className="card p-4 sm:p-5">

--- a/src/components/analytics/ai-assessment-report.tsx
+++ b/src/components/analytics/ai-assessment-report.tsx
@@ -16,11 +16,8 @@ import {
 } from "lucide-react";
 import { cn, formatCurrency } from "@/lib/utils";
 import { stagger, fadeUp } from "@/components/analytics/motion-variants";
-import {
-  useAssessmentQuery,
-  useGenerateAssessment,
-  useDailyTipQuery,
-} from "@/hooks/use-assessment";
+import { useAssessmentQuery, useDailyTipQuery } from "@/hooks/use-assessment";
+import { useAssessment, periodKeyOf } from "@/components/assessment-provider";
 import type { AnalyticsData, AiWatchSeverity } from "@/types";
 import type { AssessmentPayload } from "@/lib/ai-assessment";
 
@@ -127,15 +124,17 @@ function DailyTipCard() {
 
 export function AiAssessmentReport({ data, period, currency, hideAmounts }: AiAssessmentReportProps) {
   const { data: reportData, isLoading } = useAssessmentQuery(period);
-  const generate = useGenerateAssessment();
+  const { isGenerating, generate } = useAssessment();
 
   const payload = useMemo(() => buildPayload(data, currency, period.granularity), [data, currency, period.granularity]);
   const fmt = (n: number | null) => (n === null ? "—" : hideAmounts ? "•••" : formatCurrency(n, currency));
 
   const report = reportData?.report;
   const hasData = data.summary.transactionCount > 0;
+  const pending = isGenerating(periodKeyOf(period.granularity, period.from, period.to));
 
-  const handleGenerate = () => generate.mutate({ from: period.from, to: period.to, payload });
+  const handleGenerate = () =>
+    generate({ from: period.from, to: period.to, granularity: period.granularity, payload });
 
   return (
     <motion.div variants={stagger} initial="hidden" animate="show" className="space-y-4">
@@ -159,30 +158,32 @@ export function AiAssessmentReport({ data, period, currency, hideAmounts }: AiAs
             <button
               type="button"
               onClick={handleGenerate}
-              disabled={generate.isPending}
+              disabled={pending}
               className="inline-flex items-center gap-2 bg-amber hover:bg-amber-dark text-white font-medium text-sm px-4 py-2 rounded-xl transition-colors shadow-soft disabled:opacity-60 shrink-0"
             >
-              {generate.isPending ? (
+              {pending ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
               ) : report ? (
                 <RefreshCw className="w-4 h-4" />
               ) : (
                 <Sparkles className="w-4 h-4" />
               )}
-              {generate.isPending ? "Analyzing…" : report ? "Refresh" : "Generate"}
+              {pending ? "Analyzing…" : report ? "Refresh" : "Generate"}
             </button>
           )}
         </div>
 
-        {generate.isError && (
-          <p className="text-xs text-expense mt-3">{(generate.error as Error).message}</p>
+        {pending && (
+          <p className="text-xs text-warm-400 mt-3">
+            Analyzing in the background — feel free to browse; we&apos;ll notify you when it&apos;s ready.
+          </p>
         )}
 
         {!hasData && (
           <p className="text-sm text-warm-400 mt-3">Add some transactions for this period to get an AI assessment.</p>
         )}
 
-        {hasData && !report && !generate.isPending && !isLoading && (
+        {hasData && !report && !pending && !isLoading && (
           <p className="text-sm text-warm-500 mt-3">
             Tap <span className="font-medium">Generate</span> to have AI analyze your spending and suggest where to cut back, how to save more, and ways to earn.
           </p>

--- a/src/components/assessment-provider.tsx
+++ b/src/components/assessment-provider.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { createContext, useCallback, useContext, useState } from "react";
+import { createContext, useCallback, useContext, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/components/ui/toast";
+import { useUser } from "@/components/user-provider";
 import { assessmentKeys } from "@/hooks/use-assessment";
 import type { AssessmentPayload } from "@/lib/ai-assessment";
 import type { AiAssessmentResponse } from "@/types";
@@ -28,7 +29,11 @@ export const periodKeyOf = (granularity: string, from: string, to: string) => `$
 export function AssessmentProvider({ children }: { children: React.ReactNode }) {
   const queryClient = useQueryClient();
   const { showToast } = useToast();
+  const { user } = useUser();
   const [activeKeys, setActiveKeys] = useState<Set<string>>(new Set());
+  // Synchronous guard: React state updates are async, so two rapid clicks could
+  // both pass an `activeKeys` check in the same tick. A ref blocks duplicates immediately.
+  const inFlight = useRef<Set<string>>(new Set());
 
   const setKey = useCallback((key: string, on: boolean) => {
     setActiveKeys((prev) => {
@@ -42,7 +47,8 @@ export function AssessmentProvider({ children }: { children: React.ReactNode }) 
   const generate = useCallback(
     ({ from, to, granularity, payload }: GenerateArgs) => {
       const key = periodKeyOf(granularity, from, to);
-      if (activeKeys.has(key)) return; // already running for this period
+      if (inFlight.current.has(key)) return; // already running for this period
+      inFlight.current.add(key);
       setKey(key, true);
 
       // Fire-and-forget: not tied to any component, so it survives navigation.
@@ -59,16 +65,17 @@ export function AssessmentProvider({ children }: { children: React.ReactNode }) 
           }
           const data = (await res.json()) as AiAssessmentResponse;
           // Prime the cache so the tab shows the report immediately on return.
-          queryClient.setQueryData(assessmentKeys.report({ granularity, from, to }), data);
+          queryClient.setQueryData(assessmentKeys.report(user.email, { granularity, from, to }), data);
           showToast("AI assessment ready ✨");
         } catch (error) {
           showToast(error instanceof Error ? error.message : "Failed to generate assessment", "error");
         } finally {
+          inFlight.current.delete(key);
           setKey(key, false);
         }
       })();
     },
-    [activeKeys, setKey, queryClient, showToast]
+    [setKey, queryClient, showToast, user.email]
   );
 
   const isGenerating = useCallback((periodKey: string) => activeKeys.has(periodKey), [activeKeys]);

--- a/src/components/assessment-provider.tsx
+++ b/src/components/assessment-provider.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { createContext, useCallback, useContext, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useToast } from "@/components/ui/toast";
+import { assessmentKeys } from "@/hooks/use-assessment";
+import type { AssessmentPayload } from "@/lib/ai-assessment";
+import type { AiAssessmentResponse } from "@/types";
+
+interface GenerateArgs {
+  from: string;
+  to: string;
+  granularity: string;
+  payload: AssessmentPayload;
+}
+
+interface AssessmentContextValue {
+  /** True while a report for this exact period key is being generated. */
+  isGenerating: (periodKey: string) => boolean;
+  /** Kick off (or refresh) generation; runs in the background across navigation. */
+  generate: (args: GenerateArgs) => void;
+}
+
+const AssessmentContext = createContext<AssessmentContextValue | null>(null);
+
+export const periodKeyOf = (granularity: string, from: string, to: string) => `${granularity}:${from}:${to}`;
+
+export function AssessmentProvider({ children }: { children: React.ReactNode }) {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+  const [activeKeys, setActiveKeys] = useState<Set<string>>(new Set());
+
+  const setKey = useCallback((key: string, on: boolean) => {
+    setActiveKeys((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(key);
+      else next.delete(key);
+      return next;
+    });
+  }, []);
+
+  const generate = useCallback(
+    ({ from, to, granularity, payload }: GenerateArgs) => {
+      const key = periodKeyOf(granularity, from, to);
+      if (activeKeys.has(key)) return; // already running for this period
+      setKey(key, true);
+
+      // Fire-and-forget: not tied to any component, so it survives navigation.
+      (async () => {
+        try {
+          const res = await fetch("/api/assessment/generate", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ from, to, payload }),
+          });
+          if (!res.ok) {
+            const data = (await res.json().catch(() => null)) as { error?: string } | null;
+            throw new Error(data?.error ?? "Failed to generate assessment");
+          }
+          const data = (await res.json()) as AiAssessmentResponse;
+          // Prime the cache so the tab shows the report immediately on return.
+          queryClient.setQueryData(assessmentKeys.report({ granularity, from, to }), data);
+          showToast("AI assessment ready ✨");
+        } catch (error) {
+          showToast(error instanceof Error ? error.message : "Failed to generate assessment", "error");
+        } finally {
+          setKey(key, false);
+        }
+      })();
+    },
+    [activeKeys, setKey, queryClient, showToast]
+  );
+
+  const isGenerating = useCallback((periodKey: string) => activeKeys.has(periodKey), [activeKeys]);
+
+  return (
+    <AssessmentContext.Provider value={{ isGenerating, generate }}>
+      {children}
+    </AssessmentContext.Provider>
+  );
+}
+
+export function useAssessment() {
+  const ctx = useContext(AssessmentContext);
+  if (!ctx) throw new Error("useAssessment must be used within AssessmentProvider");
+  return ctx;
+}

--- a/src/hooks/use-assessment.ts
+++ b/src/hooks/use-assessment.ts
@@ -1,0 +1,91 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { AssessmentPayload } from "@/lib/ai-assessment";
+import type { AiAssessmentResponse, AiDailyTipResponse } from "@/types";
+
+/* ------------------------------------------------------------------ */
+/*  Keys                                                               */
+/* ------------------------------------------------------------------ */
+
+export interface AssessmentPeriod {
+  granularity: string;
+  from: string;
+  to: string;
+}
+
+export const assessmentKeys = {
+  all: ["assessment"] as const,
+  report: (p: AssessmentPeriod) => ["assessment", "report", p] as const,
+  dailyTip: ["assessment", "daily-tip"] as const,
+};
+
+/* ------------------------------------------------------------------ */
+/*  Cached report (GET)                                                */
+/* ------------------------------------------------------------------ */
+
+const fetchReport = async (p: AssessmentPeriod): Promise<AiAssessmentResponse> => {
+  const search = new URLSearchParams({ granularity: p.granularity, from: p.from, to: p.to });
+  const res = await fetch(`/api/assessment?${search}`);
+  if (!res.ok) throw new Error("Failed to load assessment");
+  return res.json();
+};
+
+export function useAssessmentQuery(p: AssessmentPeriod) {
+  return useQuery({
+    queryKey: assessmentKeys.report(p),
+    queryFn: () => fetchReport(p),
+    staleTime: Infinity, // cached server-side per period; only refetch on explicit generate
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Generate / refresh (POST)                                          */
+/* ------------------------------------------------------------------ */
+
+interface GenerateArgs {
+  from: string;
+  to: string;
+  payload: AssessmentPayload;
+}
+
+export function useGenerateAssessment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ from, to, payload }: GenerateArgs): Promise<AiAssessmentResponse> => {
+      const res = await fetch("/api/assessment/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ from, to, payload }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(data?.error ?? "Failed to generate assessment");
+      }
+      return res.json();
+    },
+    onSuccess: (data, { from, to, payload }) => {
+      queryClient.setQueryData(
+        assessmentKeys.report({ granularity: payload.granularity, from, to }),
+        data
+      );
+    },
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Daily tip (GET, lazily generated server-side)                      */
+/* ------------------------------------------------------------------ */
+
+const fetchDailyTip = async (): Promise<AiDailyTipResponse> => {
+  const res = await fetch("/api/assessment/daily-tip");
+  if (!res.ok) throw new Error("Failed to load daily tip");
+  return res.json();
+};
+
+export function useDailyTipQuery() {
+  return useQuery({
+    queryKey: assessmentKeys.dailyTip,
+    queryFn: fetchDailyTip,
+    staleTime: Infinity,
+  });
+}

--- a/src/hooks/use-assessment.ts
+++ b/src/hooks/use-assessment.ts
@@ -16,8 +16,13 @@ export interface AssessmentPeriod {
 export const assessmentKeys = {
   all: ["assessment"] as const,
   report: (userKey: string, p: AssessmentPeriod) => ["assessment", "report", userKey, p] as const,
-  dailyTip: (userKey: string) => ["assessment", "daily-tip", userKey] as const,
+  // localDate in the key so the tip naturally refetches once the user crosses local midnight.
+  dailyTip: (userKey: string, localDate: string) => ["assessment", "daily-tip", userKey, localDate] as const,
 };
+
+/** The user's current calendar date (YYYY-MM-DD) given their tz offset in minutes. */
+export const localDateFor = (timezoneOffset: number): string =>
+  new Date(Date.now() - timezoneOffset * 60_000).toISOString().slice(0, 10);
 
 /* ------------------------------------------------------------------ */
 /*  Cached report (GET)                                                */
@@ -52,7 +57,7 @@ const fetchDailyTip = async (): Promise<AiDailyTipResponse> => {
 export function useDailyTipQuery() {
   const { user } = useUser();
   return useQuery({
-    queryKey: assessmentKeys.dailyTip(user.email),
+    queryKey: assessmentKeys.dailyTip(user.email, localDateFor(user.timezoneOffset)),
     queryFn: fetchDailyTip,
     staleTime: Infinity,
   });

--- a/src/hooks/use-assessment.ts
+++ b/src/hooks/use-assessment.ts
@@ -1,8 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
+import { useUser } from "@/components/user-provider";
 import type { AiAssessmentResponse, AiDailyTipResponse } from "@/types";
 
 /* ------------------------------------------------------------------ */
-/*  Keys                                                               */
+/*  Keys — scoped by user so a shared queryClient can't leak cached    */
+/*  reports/tips across accounts on the same browser session.          */
 /* ------------------------------------------------------------------ */
 
 export interface AssessmentPeriod {
@@ -13,8 +15,8 @@ export interface AssessmentPeriod {
 
 export const assessmentKeys = {
   all: ["assessment"] as const,
-  report: (p: AssessmentPeriod) => ["assessment", "report", p] as const,
-  dailyTip: ["assessment", "daily-tip"] as const,
+  report: (userKey: string, p: AssessmentPeriod) => ["assessment", "report", userKey, p] as const,
+  dailyTip: (userKey: string) => ["assessment", "daily-tip", userKey] as const,
 };
 
 /* ------------------------------------------------------------------ */
@@ -29,8 +31,9 @@ const fetchReport = async (p: AssessmentPeriod): Promise<AiAssessmentResponse> =
 };
 
 export function useAssessmentQuery(p: AssessmentPeriod) {
+  const { user } = useUser();
   return useQuery({
-    queryKey: assessmentKeys.report(p),
+    queryKey: assessmentKeys.report(user.email, p),
     queryFn: () => fetchReport(p),
     staleTime: Infinity, // cached server-side per period; only refetch on explicit generate
   });
@@ -47,8 +50,9 @@ const fetchDailyTip = async (): Promise<AiDailyTipResponse> => {
 };
 
 export function useDailyTipQuery() {
+  const { user } = useUser();
   return useQuery({
-    queryKey: assessmentKeys.dailyTip,
+    queryKey: assessmentKeys.dailyTip(user.email),
     queryFn: fetchDailyTip,
     staleTime: Infinity,
   });

--- a/src/hooks/use-assessment.ts
+++ b/src/hooks/use-assessment.ts
@@ -51,7 +51,12 @@ export function useAssessmentQuery(p: AssessmentPeriod) {
 const fetchDailyTip = async (): Promise<AiDailyTipResponse> => {
   const res = await fetch("/api/assessment/daily-tip");
   if (!res.ok) throw new Error("Failed to load daily tip");
-  return res.json();
+  const data: AiDailyTipResponse = await res.json();
+  // The route returns 200 { tip: null } when generation transiently fails (it degrades
+  // gracefully). Treat that as an error so React Query doesn't cache the failure for the
+  // whole local day (staleTime: Infinity) — it retries on the next visit and caches once it succeeds.
+  if (!data.tip) throw new Error("Daily tip unavailable");
+  return data;
 };
 
 export function useDailyTipQuery() {

--- a/src/hooks/use-assessment.ts
+++ b/src/hooks/use-assessment.ts
@@ -1,5 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { AssessmentPayload } from "@/lib/ai-assessment";
+import { useQuery } from "@tanstack/react-query";
 import type { AiAssessmentResponse, AiDailyTipResponse } from "@/types";
 
 /* ------------------------------------------------------------------ */
@@ -34,41 +33,6 @@ export function useAssessmentQuery(p: AssessmentPeriod) {
     queryKey: assessmentKeys.report(p),
     queryFn: () => fetchReport(p),
     staleTime: Infinity, // cached server-side per period; only refetch on explicit generate
-  });
-}
-
-/* ------------------------------------------------------------------ */
-/*  Generate / refresh (POST)                                          */
-/* ------------------------------------------------------------------ */
-
-interface GenerateArgs {
-  from: string;
-  to: string;
-  payload: AssessmentPayload;
-}
-
-export function useGenerateAssessment() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async ({ from, to, payload }: GenerateArgs): Promise<AiAssessmentResponse> => {
-      const res = await fetch("/api/assessment/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ from, to, payload }),
-      });
-      if (!res.ok) {
-        const data = (await res.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(data?.error ?? "Failed to generate assessment");
-      }
-      return res.json();
-    },
-    onSuccess: (data, { from, to, payload }) => {
-      queryClient.setQueryData(
-        assessmentKeys.report({ granularity: payload.granularity, from, to }),
-        data
-      );
-    },
   });
 }
 

--- a/src/lib/ai-assessment.ts
+++ b/src/lib/ai-assessment.ts
@@ -55,17 +55,15 @@ export const assessmentPayloadSchema = z.object({
       consistency: subScoreSchema,
     }),
   }),
+  // All-types only — the Reports type filter must not skew the assessment, and the
+  // cache key is type-independent, so type-filtered fields (labels, top transactions)
+  // are intentionally excluded. The statistics block below carries the all-types highlights.
   categoryBreakdown: z.array(z.object({
     name: NAME,
     type: z.enum(["INCOME", "EXPENSE"]),
     amount: z.number(),
     percentage: z.number(),
     transactionCount: z.number(),
-  })).max(100).default([]),
-  labelBreakdown: z.array(z.object({
-    name: NAME,
-    amount: z.number(),
-    percentage: z.number(),
   })).max(100).default([]),
   statistics: z.object({
     avgDailySpend: z.number().nullable(),
@@ -78,13 +76,6 @@ export const assessmentPayloadSchema = z.object({
     mostUsedCategory: z.object({ name: NAME, count: z.number() }).nullable(),
     mostExpensiveCategory: z.object({ name: NAME, amount: z.number() }).nullable(),
   }),
-  topTransactions: z.array(z.object({
-    description: z.string().max(200),
-    amount: z.number(),
-    type: z.enum(["INCOME", "EXPENSE"]),
-    categoryName: NAME,
-    dateLabel: LABEL,
-  })).max(50).default([]),
 });
 
 export type AssessmentPayload = z.infer<typeof assessmentPayloadSchema>;
@@ -191,7 +182,6 @@ const buildDataSnapshot = (p: AssessmentPayload, bills: UpcomingBillsContext): s
       pctOfSpend: Math.round(c.percentage),
       count: c.transactionCount,
     })),
-    topLabels: p.labelBreakdown.slice(0, 5).map((l) => ({ name: l.name, amount: l.amount, pct: Math.round(l.percentage) })),
     stats: {
       avgDailySpend: p.statistics.avgDailySpend,
       avgExpenseSize: p.statistics.avgExpenseSize,
@@ -202,13 +192,6 @@ const buildDataSnapshot = (p: AssessmentPayload, bills: UpcomingBillsContext): s
       mostUsedCategory: p.statistics.mostUsedCategory?.name ?? null,
       mostExpensiveCategory: p.statistics.mostExpensiveCategory?.name ?? null,
     },
-    biggestTransactions: p.topTransactions.slice(0, 5).map((t) => ({
-      description: t.description,
-      amount: t.amount,
-      type: t.type,
-      category: t.categoryName,
-      when: t.dateLabel,
-    })),
     upcomingBills: {
       count: bills.count,
       total: bills.totalAmount,

--- a/src/lib/ai-assessment.ts
+++ b/src/lib/ai-assessment.ts
@@ -29,18 +29,23 @@ const subScoreSchema = z.object({
   trend: z.string(),
 });
 
+/* Bounds on the client-supplied payload so a crafted request can't blow up the
+ * prompt size / token cost. The snapshot only uses the top handful anyway. */
+const NAME = z.string().max(120);
+const LABEL = z.string().max(60);
+
 /** The slice of AnalyticsData the AI needs, sent by the client for the selected period. */
 export const assessmentPayloadSchema = z.object({
-  currency: z.string().default("PHP"),
+  currency: z.string().max(10).default("PHP"),
   granularity: z.enum(["weekly", "monthly", "yearly"]),
-  periodLabel: z.string().default(""),
-  previousPeriodLabel: z.string().default(""),
+  periodLabel: z.string().max(120).default(""),
+  previousPeriodLabel: z.string().max(120).default(""),
   summary: summarySchema,
   previousSummary: summarySchema,
   healthScore: z.object({
     overallScore: z.number(),
-    overallLabel: z.string(),
-    overallTrend: z.string(),
+    overallLabel: LABEL,
+    overallTrend: LABEL,
     savingsRate: z.number().nullable(),
     subScores: z.object({
       savingsRate: subScoreSchema,
@@ -51,17 +56,17 @@ export const assessmentPayloadSchema = z.object({
     }),
   }),
   categoryBreakdown: z.array(z.object({
-    name: z.string(),
+    name: NAME,
     type: z.enum(["INCOME", "EXPENSE"]),
     amount: z.number(),
     percentage: z.number(),
     transactionCount: z.number(),
-  })).default([]),
+  })).max(100).default([]),
   labelBreakdown: z.array(z.object({
-    name: z.string(),
+    name: NAME,
     amount: z.number(),
     percentage: z.number(),
-  })).default([]),
+  })).max(100).default([]),
   statistics: z.object({
     avgDailySpend: z.number().nullable(),
     avgExpenseSize: z.number().nullable(),
@@ -70,16 +75,16 @@ export const assessmentPayloadSchema = z.object({
     totalDaysInPeriod: z.number(),
     totalTransactions: z.number(),
     categoriesUsed: z.number(),
-    mostUsedCategory: z.object({ name: z.string(), count: z.number() }).nullable(),
-    mostExpensiveCategory: z.object({ name: z.string(), amount: z.number() }).nullable(),
+    mostUsedCategory: z.object({ name: NAME, count: z.number() }).nullable(),
+    mostExpensiveCategory: z.object({ name: NAME, amount: z.number() }).nullable(),
   }),
   topTransactions: z.array(z.object({
-    description: z.string(),
+    description: z.string().max(200),
     amount: z.number(),
     type: z.enum(["INCOME", "EXPENSE"]),
-    categoryName: z.string(),
-    dateLabel: z.string(),
-  })).default([]),
+    categoryName: NAME,
+    dateLabel: LABEL,
+  })).max(50).default([]),
 });
 
 export type AssessmentPayload = z.infer<typeof assessmentPayloadSchema>;
@@ -137,7 +142,8 @@ const extractSources = (response: { candidates?: Array<{ groundingMetadata?: { g
   const sources: AiSource[] = [];
   for (const chunk of chunks) {
     const uri = chunk.web?.uri;
-    if (uri && !seen.has(uri)) {
+    // Only trust http(s) links — the URI comes from the model; block javascript:/data: etc.
+    if (uri && /^https?:\/\//i.test(uri) && !seen.has(uri)) {
       seen.add(uri);
       sources.push({ title: chunk.web?.title ?? uri, url: uri });
     }

--- a/src/lib/ai-assessment.ts
+++ b/src/lib/ai-assessment.ts
@@ -246,8 +246,17 @@ Respond with ONLY valid JSON (no markdown), shape:
     config: receiptScanConfig(),
   });
   const parsed = assessmentReportSchema.safeParse(parseJsonObject(response.text));
-  if (!parsed.success) throw new Error("Failed to parse AI assessment response");
-  return parsed.data;
+  if (!parsed.success) {
+    console.error("[ai-assessment] report parse failed:", parsed.error.issues.map((i) => i.path.join(".")).join(", ") || "non-object response");
+    throw new Error("Failed to parse AI assessment response");
+  }
+  const r = parsed.data;
+  const isEmpty =
+    !r.summary && !r.scoreCommentary &&
+    r.watchList.length === 0 && r.cutBack.length === 0 &&
+    r.boostSavings.length === 0 && r.earnIdeas.length === 0 && r.quickActions.length === 0;
+  if (isEmpty) throw new Error("AI returned an empty assessment");
+  return r;
 };
 
 /** Grounded web tips + sources (Google Search). Degrades to empty on failure. */

--- a/src/lib/ai-assessment.ts
+++ b/src/lib/ai-assessment.ts
@@ -1,0 +1,357 @@
+import { z } from "zod";
+import {
+  GEMINI_MODEL,
+  GEMINI_TIMEOUT_MS,
+  generateContentWithRetry,
+  receiptScanConfig,
+} from "@/lib/gemini";
+import {
+  assessmentReportSchema,
+  webTipsSchema,
+  dailyTipSchema,
+} from "@/lib/validations";
+import type { AiAssessmentReport, AiDailyTip, AiSource } from "@/types";
+
+/* ------------------------------------------------------------------ */
+/*  Input payload (sent by the client from its already-computed data)  */
+/* ------------------------------------------------------------------ */
+
+const summarySchema = z.object({
+  totalIncome: z.number(),
+  totalExpenses: z.number(),
+  netCashFlow: z.number(),
+  transactionCount: z.number(),
+});
+
+const subScoreSchema = z.object({
+  score: z.number(),
+  label: z.string(),
+  trend: z.string(),
+});
+
+/** The slice of AnalyticsData the AI needs, sent by the client for the selected period. */
+export const assessmentPayloadSchema = z.object({
+  currency: z.string().default("PHP"),
+  granularity: z.enum(["weekly", "monthly", "yearly"]),
+  periodLabel: z.string().default(""),
+  previousPeriodLabel: z.string().default(""),
+  summary: summarySchema,
+  previousSummary: summarySchema,
+  healthScore: z.object({
+    overallScore: z.number(),
+    overallLabel: z.string(),
+    overallTrend: z.string(),
+    savingsRate: z.number().nullable(),
+    subScores: z.object({
+      savingsRate: subScoreSchema,
+      expenseTrend: subScoreSchema,
+      incomeStability: subScoreSchema,
+      diversification: subScoreSchema,
+      consistency: subScoreSchema,
+    }),
+  }),
+  categoryBreakdown: z.array(z.object({
+    name: z.string(),
+    type: z.enum(["INCOME", "EXPENSE"]),
+    amount: z.number(),
+    percentage: z.number(),
+    transactionCount: z.number(),
+  })).default([]),
+  labelBreakdown: z.array(z.object({
+    name: z.string(),
+    amount: z.number(),
+    percentage: z.number(),
+  })).default([]),
+  statistics: z.object({
+    avgDailySpend: z.number().nullable(),
+    avgExpenseSize: z.number().nullable(),
+    spendingStreak: z.number(),
+    activeDays: z.number(),
+    totalDaysInPeriod: z.number(),
+    totalTransactions: z.number(),
+    categoriesUsed: z.number(),
+    mostUsedCategory: z.object({ name: z.string(), count: z.number() }).nullable(),
+    mostExpensiveCategory: z.object({ name: z.string(), amount: z.number() }).nullable(),
+  }),
+  topTransactions: z.array(z.object({
+    description: z.string(),
+    amount: z.number(),
+    type: z.enum(["INCOME", "EXPENSE"]),
+    categoryName: z.string(),
+    dateLabel: z.string(),
+  })).default([]),
+});
+
+export type AssessmentPayload = z.infer<typeof assessmentPayloadSchema>;
+
+/** Upcoming recurring bills, fetched server-side and merged into the prompt. */
+export interface UpcomingBillsContext {
+  count: number;
+  totalAmount: number;
+  bills: Array<{ description: string; categoryName: string; amount: number; dueDate: string; isOverdue: boolean }>;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/** Best-effort region hint from the user's currency (drives localized tips). */
+const REGION_BY_CURRENCY: Record<string, string> = {
+  PHP: "the Philippines",
+  USD: "the United States",
+  EUR: "the Eurozone",
+  GBP: "the United Kingdom",
+  AUD: "Australia",
+  CAD: "Canada",
+  SGD: "Singapore",
+  INR: "India",
+  JPY: "Japan",
+};
+const regionFor = (currency: string): string => REGION_BY_CURRENCY[currency.toUpperCase()] ?? "the user's country";
+
+/** Strip markdown fences / surrounding prose and parse the first JSON object. */
+const parseJsonObject = (raw: string | undefined): unknown => {
+  if (!raw) return null;
+  const text = raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "").trim();
+  try {
+    return JSON.parse(text);
+  } catch {
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start !== -1 && end > start) {
+      try {
+        return JSON.parse(text.slice(start, end + 1));
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+};
+
+/** Pull grounding source links out of a Gemini response's grounding metadata. */
+interface GroundingChunk { web?: { uri?: string; title?: string } }
+const extractSources = (response: { candidates?: Array<{ groundingMetadata?: { groundingChunks?: GroundingChunk[] } }> }): AiSource[] => {
+  const chunks = response.candidates?.[0]?.groundingMetadata?.groundingChunks ?? [];
+  const seen = new Set<string>();
+  const sources: AiSource[] = [];
+  for (const chunk of chunks) {
+    const uri = chunk.web?.uri;
+    if (uri && !seen.has(uri)) {
+      seen.add(uri);
+      sources.push({ title: chunk.web?.title ?? uri, url: uri });
+    }
+  }
+  return sources.slice(0, 8);
+};
+
+/** Compact, numbers-included snapshot the model reasons over. */
+const buildDataSnapshot = (p: AssessmentPayload, bills: UpcomingBillsContext): string => {
+  const h = p.healthScore;
+  const topExpenseCats = p.categoryBreakdown.filter((c) => c.type === "EXPENSE").slice(0, 8);
+  const subs = h.subScores;
+  return JSON.stringify({
+    currency: p.currency,
+    period: p.periodLabel,
+    previousPeriod: p.previousPeriodLabel,
+    granularity: p.granularity,
+    totals: {
+      income: p.summary.totalIncome,
+      expenses: p.summary.totalExpenses,
+      net: p.summary.netCashFlow,
+      transactions: p.summary.transactionCount,
+    },
+    previousTotals: {
+      income: p.previousSummary.totalIncome,
+      expenses: p.previousSummary.totalExpenses,
+      net: p.previousSummary.netCashFlow,
+    },
+    healthScore: {
+      overall: h.overallScore,
+      label: h.overallLabel,
+      trend: h.overallTrend,
+      savingsRatePct: h.savingsRate === null ? null : Math.round(h.savingsRate * 100),
+      subScores: {
+        savingsRate: { score: subs.savingsRate.score, trend: subs.savingsRate.trend },
+        expenseTrend: { score: subs.expenseTrend.score, trend: subs.expenseTrend.trend },
+        incomeStability: { score: subs.incomeStability.score, trend: subs.incomeStability.trend },
+        diversification: { score: subs.diversification.score, trend: subs.diversification.trend },
+        consistency: { score: subs.consistency.score, trend: subs.consistency.trend },
+      },
+    },
+    topExpenseCategories: topExpenseCats.map((c) => ({
+      name: c.name,
+      amount: c.amount,
+      pctOfSpend: Math.round(c.percentage),
+      count: c.transactionCount,
+    })),
+    topLabels: p.labelBreakdown.slice(0, 5).map((l) => ({ name: l.name, amount: l.amount, pct: Math.round(l.percentage) })),
+    stats: {
+      avgDailySpend: p.statistics.avgDailySpend,
+      avgExpenseSize: p.statistics.avgExpenseSize,
+      spendingStreakDays: p.statistics.spendingStreak,
+      activeDays: p.statistics.activeDays,
+      daysInPeriod: p.statistics.totalDaysInPeriod,
+      categoriesUsed: p.statistics.categoriesUsed,
+      mostUsedCategory: p.statistics.mostUsedCategory?.name ?? null,
+      mostExpensiveCategory: p.statistics.mostExpensiveCategory?.name ?? null,
+    },
+    biggestTransactions: p.topTransactions.slice(0, 5).map((t) => ({
+      description: t.description,
+      amount: t.amount,
+      type: t.type,
+      category: t.categoryName,
+      when: t.dateLabel,
+    })),
+    upcomingBills: {
+      count: bills.count,
+      total: bills.totalAmount,
+      items: bills.bills.slice(0, 8).map((b) => ({ name: b.description, category: b.categoryName, amount: b.amount, overdue: b.isOverdue })),
+    },
+  });
+};
+
+const PRIVACY_RULE =
+  "Express insights using PERCENTAGES and RELATIVE terms (e.g. \"dining is ~18% of spending, up 12% vs last period\"). " +
+  "Do NOT write raw currency amounts in any prose text. Only the `estimatedMonthlySaving` field may hold a number.";
+
+/* ------------------------------------------------------------------ */
+/*  Generation                                                         */
+/* ------------------------------------------------------------------ */
+
+/** Data-driven structured assessment (no web tools). */
+const generateAssessmentBody = async (snapshot: string, region: string) => {
+  const prompt = `You are a practical, encouraging personal finance coach for someone in ${region}.
+Analyze this user's financial data for the period and produce a concise, specific assessment.
+
+DATA (JSON):
+${snapshot}
+
+RULES:
+- ${PRIVACY_RULE}
+- Be specific: reference the user's actual category names and trends from the data.
+- Keep each item short and actionable. Avoid generic filler.
+- "watchList": 2-4 areas to keep an eye on (rising categories, weak sub-scores), each with a severity of "high" | "medium" | "low".
+- "cutBack": 2-4 concrete categories/habits to reduce, each with a reason, a suggestion, and estimatedMonthlySaving (a number in the user's currency, or null if unknown).
+- "boostSavings": 2-4 savings strategies tailored to the data.
+- "earnIdeas": 2-3 realistic ways to earn more, relevant to ${region}.
+- "quickActions": 3-5 short next steps.
+
+Respond with ONLY valid JSON (no markdown), shape:
+{"summary": string, "scoreCommentary": string, "watchList": [{"title": string, "detail": string, "severity": "high"|"medium"|"low"}], "cutBack": [{"title": string, "reason": string, "suggestion": string, "estimatedMonthlySaving": number|null}], "boostSavings": [{"title": string, "detail": string}], "earnIdeas": [{"title": string, "detail": string}], "quickActions": [string]}`;
+
+  const response = await generateContentWithRetry({
+    model: GEMINI_MODEL,
+    contents: prompt,
+    config: receiptScanConfig(),
+  });
+  const parsed = assessmentReportSchema.safeParse(parseJsonObject(response.text));
+  if (!parsed.success) throw new Error("Failed to parse AI assessment response");
+  return parsed.data;
+};
+
+/** Grounded web tips + sources (Google Search). Degrades to empty on failure. */
+const generateWebTips = async (snapshot: string, region: string): Promise<{ webTips: AiAssessmentReport["webTips"]; sources: AiSource[] }> => {
+  const prompt = `You are a personal finance researcher for someone in ${region}. Using current, reputable web sources, find practical tips to help this user SAVE more and EARN more, tailored to ${region} and their situation.
+
+USER SITUATION (JSON):
+${snapshot}
+
+RULES:
+- Localize to ${region} (e.g. local high-yield/digital banks, local side-hustles, region-specific programs).
+- Make tips actionable and current; prefer reputable finance/savings sources and well-known community guidance.
+- Do NOT include raw currency amounts in prose.
+- Return 4-6 tips.
+
+Respond with ONLY valid JSON (no markdown): {"webTips": [{"title": string, "detail": string}]}`;
+
+  try {
+    const response = await generateContentWithRetry({
+      model: GEMINI_MODEL,
+      contents: prompt,
+      config: {
+        tools: [{ googleSearch: {} }],
+        ...(GEMINI_TIMEOUT_MS > 0 && { httpOptions: { timeout: GEMINI_TIMEOUT_MS } }),
+      },
+    });
+    const parsed = webTipsSchema.safeParse(parseJsonObject(response.text));
+    return {
+      webTips: parsed.success ? parsed.data.webTips : [],
+      sources: extractSources(response),
+    };
+  } catch {
+    return { webTips: [], sources: [] };
+  }
+};
+
+/** Generate the full assessment report (parallel data + grounded calls). */
+export const generateAssessment = async (
+  payload: AssessmentPayload,
+  bills: UpcomingBillsContext
+): Promise<{ report: AiAssessmentReport; sources: AiSource[]; model: string }> => {
+  const snapshot = buildDataSnapshot(payload, bills);
+  const region = regionFor(payload.currency);
+
+  const [body, web] = await Promise.all([
+    generateAssessmentBody(snapshot, region),
+    generateWebTips(snapshot, region),
+  ]);
+
+  const report: AiAssessmentReport = {
+    ...body,
+    webTips: web.webTips,
+    sources: web.sources,
+  };
+  return { report, sources: web.sources, model: GEMINI_MODEL };
+};
+
+/** Minimal, server-buildable context for the daily tip (current-month oriented). */
+export interface DailyTipInput {
+  currency: string;
+  monthLabel: string;
+  income: number;
+  expenses: number;
+  net: number;
+  topCategories: Array<{ name: string; amount: number; pct: number }>;
+  upcomingBills: UpcomingBillsContext;
+}
+
+/** Generate a lightweight daily tip (no grounding — personalized to current-month data). */
+export const generateDailyTip = async (
+  input: DailyTipInput
+): Promise<{ tip: AiDailyTip; model: string }> => {
+  const region = regionFor(input.currency);
+  const snapshot = JSON.stringify({
+    currency: input.currency,
+    month: input.monthLabel,
+    income: input.income,
+    expenses: input.expenses,
+    net: input.net,
+    topCategories: input.topCategories.slice(0, 6),
+    upcomingBills: {
+      count: input.upcomingBills.count,
+      total: input.upcomingBills.totalAmount,
+      items: input.upcomingBills.bills.slice(0, 6).map((b) => ({ name: b.description, amount: b.amount, overdue: b.isOverdue })),
+    },
+  });
+  const prompt = `You are a friendly money coach for someone in ${region}. From this user's current-month data, give ONE short, specific money tip for today (saving or earning).
+
+DATA (JSON):
+${snapshot}
+
+RULES:
+- ${PRIVACY_RULE}
+- One tip only; reference something concrete from their data.
+- Keep it under 2 sentences.
+
+Respond with ONLY valid JSON (no markdown): {"tip": string, "rationale": string}`;
+
+  const response = await generateContentWithRetry({
+    model: GEMINI_MODEL,
+    contents: prompt,
+    config: receiptScanConfig(),
+  });
+  const parsed = dailyTipSchema.safeParse(parseJsonObject(response.text));
+  if (!parsed.success) throw new Error("Failed to parse AI daily tip response");
+  return { tip: parsed.data, model: GEMINI_MODEL };
+};

--- a/src/lib/budget-queries.ts
+++ b/src/lib/budget-queries.ts
@@ -378,8 +378,16 @@ export const getUpcomingBills = async (
 ): Promise<UpcomingBillsResult> => {
   const days = params.days ?? 7;
 
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  // When a timezone offset is given, anchor "today" to the user's local day (mirrors
+  // /api/bills/upcoming) so AI bill context matches what the user sees on the dashboard.
+  let today: Date;
+  if (params.timezoneOffset !== undefined) {
+    const localNow = new Date(Date.now() - params.timezoneOffset * 60 * 1000);
+    today = new Date(Date.UTC(localNow.getUTCFullYear(), localNow.getUTCMonth(), localNow.getUTCDate()));
+  } else {
+    today = new Date();
+    today.setHours(0, 0, 0, 0);
+  }
 
   const cutoff = new Date(today);
   cutoff.setDate(cutoff.getDate() + days);

--- a/src/lib/budget-query-types.ts
+++ b/src/lib/budget-query-types.ts
@@ -149,6 +149,9 @@ export interface BudgetOverview {
 export interface UpcomingBillsParams {
   /** Number of days to look ahead. Defaults to 7 */
   days?: number;
+  /** User's timezone offset in minutes; when set, "today"/overdue are computed in the
+   *  user's local day (matching /api/bills/upcoming). Omit to use the server's local day. */
+  timezoneOffset?: number;
 }
 
 export interface UpcomingBill {

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -189,38 +189,61 @@ export type AnalyticsQueryInput = z.infer<typeof analyticsQuerySchema>;
 /*  AI Assessment                                                      */
 /* ------------------------------------------------------------------ */
 
-/** Validates the structured-JSON assessment returned by the data-analysis Gemini call. */
+/* LLM output is variable — these helpers normalize common quirks so valid-but-messy
+ * responses still parse instead of failing the whole generation. */
+
+/** Accepts "High"/"moderate"/etc. → high|medium|low, defaulting to "medium". */
+const severityField = z
+  .preprocess((v) => {
+    if (typeof v !== "string") return "medium";
+    const s = v.toLowerCase();
+    if (s.startsWith("h") || s.includes("critical") || s.includes("urgent")) return "high";
+    if (s.startsWith("l") || s.includes("minor")) return "low";
+    return "medium";
+  }, z.enum(["high", "medium", "low"]))
+  .catch("medium");
+
+/** Accepts a number, "₱9,000", "9000", null/"" → number | null. */
+const moneyField = z
+  .preprocess((v) => {
+    if (typeof v === "number") return Number.isFinite(v) ? v : null;
+    if (typeof v === "string") {
+      const n = Number(v.replace(/[^0-9.]/g, ""));
+      return Number.isFinite(n) && v.trim() !== "" ? n : null;
+    }
+    return null;
+  }, z.number().nonnegative().nullable())
+  .catch(null);
+
+const tipField = z.object({
+  title: z.string().catch(""),
+  detail: z.string().catch(""),
+});
+
+/** Validates the structured-JSON assessment. Resilient: bad/extra fields fall back
+ *  to safe defaults rather than failing the whole parse. */
 export const assessmentReportSchema = z.object({
-  summary: z.string().min(1).max(1200),
-  scoreCommentary: z.string().min(1).max(800),
+  summary: z.string().catch(""),
+  scoreCommentary: z.string().catch(""),
   watchList: z.array(z.object({
-    title: z.string().min(1).max(120),
-    detail: z.string().min(1).max(600),
-    severity: z.enum(["high", "medium", "low"]),
-  })).max(6).default([]),
+    title: z.string().catch(""),
+    detail: z.string().catch(""),
+    severity: severityField,
+  })).catch([]),
   cutBack: z.array(z.object({
-    title: z.string().min(1).max(120),
-    reason: z.string().min(1).max(600),
-    suggestion: z.string().min(1).max(600),
-    estimatedMonthlySaving: z.number().nonnegative().nullable().default(null),
-  })).max(6).default([]),
-  boostSavings: z.array(z.object({
-    title: z.string().min(1).max(120),
-    detail: z.string().min(1).max(600),
-  })).max(6).default([]),
-  earnIdeas: z.array(z.object({
-    title: z.string().min(1).max(120),
-    detail: z.string().min(1).max(600),
-  })).max(6).default([]),
-  quickActions: z.array(z.string().min(1).max(200)).max(6).default([]),
+    title: z.string().catch(""),
+    reason: z.string().catch(""),
+    suggestion: z.string().catch(""),
+    estimatedMonthlySaving: moneyField,
+  })).catch([]),
+  boostSavings: z.array(tipField).catch([]),
+  earnIdeas: z.array(tipField).catch([]),
+  quickActions: z.array(z.string()).catch([]),
 });
 
 /** Validates the grounded web-tips JSON (sources come separately from grounding metadata). */
 export const webTipsSchema = z.object({
-  webTips: z.array(z.object({
-    title: z.string().min(1).max(160),
-    detail: z.string().min(1).max(600),
-  })).max(8).default([]),
+  webTips: z.array(tipField).catch([]),
 });
 
 /** Validates the lightweight daily tip JSON. */

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -185,6 +185,54 @@ export const analyticsQuerySchema = z.object({
 
 export type AnalyticsQueryInput = z.infer<typeof analyticsQuerySchema>;
 
+/* ------------------------------------------------------------------ */
+/*  AI Assessment                                                      */
+/* ------------------------------------------------------------------ */
+
+/** Validates the structured-JSON assessment returned by the data-analysis Gemini call. */
+export const assessmentReportSchema = z.object({
+  summary: z.string().min(1).max(1200),
+  scoreCommentary: z.string().min(1).max(800),
+  watchList: z.array(z.object({
+    title: z.string().min(1).max(120),
+    detail: z.string().min(1).max(600),
+    severity: z.enum(["high", "medium", "low"]),
+  })).max(6).default([]),
+  cutBack: z.array(z.object({
+    title: z.string().min(1).max(120),
+    reason: z.string().min(1).max(600),
+    suggestion: z.string().min(1).max(600),
+    estimatedMonthlySaving: z.number().nonnegative().nullable().default(null),
+  })).max(6).default([]),
+  boostSavings: z.array(z.object({
+    title: z.string().min(1).max(120),
+    detail: z.string().min(1).max(600),
+  })).max(6).default([]),
+  earnIdeas: z.array(z.object({
+    title: z.string().min(1).max(120),
+    detail: z.string().min(1).max(600),
+  })).max(6).default([]),
+  quickActions: z.array(z.string().min(1).max(200)).max(6).default([]),
+});
+
+/** Validates the grounded web-tips JSON (sources come separately from grounding metadata). */
+export const webTipsSchema = z.object({
+  webTips: z.array(z.object({
+    title: z.string().min(1).max(160),
+    detail: z.string().min(1).max(600),
+  })).max(8).default([]),
+});
+
+/** Validates the lightweight daily tip JSON. */
+export const dailyTipSchema = z.object({
+  tip: z.string().min(1).max(400),
+  rationale: z.string().min(1).max(400),
+});
+
+export type AssessmentReportResult = z.infer<typeof assessmentReportSchema>;
+export type WebTipsResult = z.infer<typeof webTipsSchema>;
+export type DailyTipResult = z.infer<typeof dailyTipSchema>;
+
 export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
 export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;
 export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -311,6 +311,80 @@ export interface AnalyticsData {
   topTransactions: AnalyticsTopTransaction[];
 }
 
+/* ------------------------------------------------------------------ */
+/*  AI Assessment                                                      */
+/* ------------------------------------------------------------------ */
+
+/** Severity for a "watch list" item in the AI assessment */
+export type AiWatchSeverity = "high" | "medium" | "low";
+
+/** A flagged area the user should keep an eye on */
+export interface AiWatchItem {
+  title: string;
+  detail: string;
+  severity: AiWatchSeverity;
+}
+
+/** A category/habit the AI suggests cutting back, with an optional est. monthly saving */
+export interface AiCutBackItem {
+  title: string;
+  reason: string;
+  suggestion: string;
+  /** Estimated monthly saving in the user's currency (number; masked client-side) */
+  estimatedMonthlySaving: number | null;
+}
+
+/** A titled tip with a short body (used for savings strategy & earn ideas) */
+export interface AiTip {
+  title: string;
+  detail: string;
+}
+
+/** A web-informed tip surfaced via Google Search grounding */
+export interface AiWebTip {
+  title: string;
+  detail: string;
+}
+
+/** A grounding source (from Gemini grounding metadata) backing the web tips */
+export interface AiSource {
+  title: string;
+  url: string;
+}
+
+/** Full AI assessment report content (stored as JSON, validated by Zod) */
+export interface AiAssessmentReport {
+  summary: string;
+  scoreCommentary: string;
+  watchList: AiWatchItem[];
+  cutBack: AiCutBackItem[];
+  boostSavings: AiTip[];
+  earnIdeas: AiTip[];
+  quickActions: string[];
+  webTips: AiWebTip[];
+  /** Grounding sources backing the web tips (may be empty) */
+  sources: AiSource[];
+}
+
+/** Lightweight daily save/earn micro-tip */
+export interface AiDailyTip {
+  tip: string;
+  rationale: string;
+}
+
+/** GET /api/assessment response: the cached report (or null) + when it was made */
+export interface AiAssessmentResponse {
+  report: AiAssessmentReport | null;
+  generatedAt: string | null;
+  model: string | null;
+}
+
+/** GET /api/assessment/daily-tip response */
+export interface AiDailyTipResponse {
+  tip: AiDailyTip | null;
+  generatedAt: string | null;
+}
+
 /** Extend next-auth types */
 declare module "next-auth" {
   interface Session {


### PR DESCRIPTION
## Summary
Adds a 4th Analytics tab — **AI Assessment** — where Gemini analyzes the user's already-computed financials for the selected period and returns personalized guidance, plus a daily tip.

## What it does
- **AI report** (on-demand, "Generate / Refresh"): Summary + score commentary, **Watch list** (severity-tagged), **Cut back** (with est. monthly savings), **Boost savings**, **Ways to earn**, **Quick actions**
- **Tips from the web**: Gemini **Google Search grounding**, localized to the user's currency/region (e.g. PHP → Philippines), with linked **sources**
- **Daily tip** card: a lightweight save/earn nudge, lazily generated once per local day and cached

## How it works (cost-aware)
- Built from the **already-fetched `AnalyticsData`** (+ `getUpcomingBills`) — no heavy new server queries
- **Two parallel Gemini calls** per report: structured JSON assessment (from data) + grounded web tips. Decoupled to avoid the documented "grounding empties citations under JSON mode" pitfall and cut latency. Reuses `generateContentWithRetry` + config from `src/lib/gemini.ts`
- **On-demand + cached in DB** keyed by `granularity:from:to` → revisits don't re-call; **Refresh** re-runs (per-day cap)
- **Privacy by construction**: prose uses relative/percentage language (no raw amounts); numeric fields respect Hide Amounts

## ⚠️ Migration (production-affecting, additive)
- New models **`AiAssessment`** (report/daily-tip cache) + **`AiUsageLog`** (per-day cap) — migration `20260615120000_add_ai_assessment`
- Additive only (no changes to existing tables); on production the build runs `prisma migrate deploy`
- The migration was hand-written to add **only** the new tables/enum (avoids touching the pre-existing `labels` index drift that `migrate dev` wanted to "fix")

## Config
- **No new required env vars** — reuses `GEMINI_API_KEY` / `GEMINI_MODEL`
- Optional `AI_ASSESSMENT_DAILY_LIMIT` (default `10`) caps manual report generations per user per day; cached reports and the daily tip don't count

## New files
- `src/lib/ai-assessment.ts`, `src/app/api/assessment/{route,generate/route,daily-tip/route}.ts`, `src/hooks/use-assessment.ts`, `src/components/analytics/ai-assessment-report.tsx`
- Edits: analytics `page.tsx` (4th tab), `validations.ts` (Zod), `types/index.ts`, docs

## Notes / scope
- v1 is available to all signed-in users; role/feature gating (like receipt scan) is a noted follow-up
- Grounding adds per-call cost; mitigated by caching + the daily cap
- If grounding misbehaves on the deployed model, the assessment still works and the web-tips section degrades to empty

## Test plan
- [ ] Analytics → **AI Assessment**: daily-tip card loads (then cached)
- [ ] Empty state → **Generate** → all sections render; "Tips from the web" shows working source links
- [ ] **Refresh** re-runs; switch period (week/month/year) → distinct cached reports; revisit → instant (no new call)
- [ ] Toggle **Hide amounts** → numeric fields mask; prose stays relative
- [ ] Period with no transactions → "add transactions" empty state
- [ ] Exceed daily cap → friendly 429 message; Gemini busy → 503 handled

## Verification
- ✅ `pnpm type-check`
- ✅ `pnpm lint` (No ESLint warnings or errors)
- ✅ `next build` (all routes compile)
- ✅ `prisma migrate deploy` applied locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New Gemini-backed endpoints send financial snapshots to a third-party API and add a production migration; mitigations include caching, daily caps, and privacy-oriented prompts/masking, but cost and data-exposure surface area increase.
> 
> **Overview**
> Adds a fourth **AI Assessment** tab on Analytics that turns the period’s existing `AnalyticsData` into on-demand Gemini guidance, plus a cached daily tip card.
> 
> **Generate / Refresh** runs **two parallel Gemini calls** (structured JSON from analytics + Google Search–grounded web tips with linked sources), stores results in new **`AiAssessment`** rows keyed by `granularity:from:to`, and surfaces watch list, cut back (with optional monthly savings), savings/earn ideas, and quick actions. **`AssessmentProvider`** keeps generation in the background across navigation and toasts when ready. **Hide amounts** masks numeric fields and regex-masks currency in prose.
> 
> New authenticated routes: `GET /api/assessment`, `POST /api/assessment/generate`, `GET /api/assessment/daily-tip`. Report generations are capped per user per local day via **`AiUsageLog`** and optional **`AI_ASSESSMENT_DAILY_LIMIT`** (quota reserved before Gemini, rolled back on failure). Daily tips use current-month budget queries and cache per local day. **`getUpcomingBills`** gains optional **`timezoneOffset`** so bill context matches the user’s day.
> 
> Additive Prisma migration **`20260615120000_add_ai_assessment`**; docs/changelog/env example updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8465df7fa60d307c67988ab0881534dd92b95464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "AI Assessment" tab in Analytics with AI-generated financial insights, including watch lists, cost-cutting suggestions, earning ideas, and quick actions
  * Generate or refresh assessment reports for custom date ranges
  * New daily tip feature with smart caching
  * Daily generation limit per user for AI assessments (configurable)

* **Documentation**
  * Updated documentation to reference new AI Assessment feature and environment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->