### PR TITLE
feat(api): add liveness health endpoint for container healthchecks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,7 @@ Active tasks:
 - `POST /api/email/reset-password` — validate token + update password
 - `POST /api/resend-verification` — resend verification email
 - `GET /api/cron/bill-reminders` — sends email reminders for pending bills (secured with `CRON_SECRET`); triggered daily by a Coolify Scheduled Task on production
+- `GET /api/health` — container liveness probe for the Coolify/Docker healthcheck; unauthenticated and deliberately touches no database (a deep check would restart every app on the shared Postgres during one blip)
 
 ## Design
 - "Light & Warm" aesthetic with cream/paper-like backgrounds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable development history for the Budget Tracker app.
 
+## 2026-07-28 — Container Liveness Endpoint
+
+### Health Check
+- Added `GET /api/health` returning `{ status: "ok" }` for the Coolify/Docker container healthcheck
+- Probe is shallow by design: no database and no auth. Every app on this host shares one Postgres instance, so a deep check would mark them all unhealthy during a single database blip and restart the lot at once
+- `dynamic = "force-dynamic"` pinned so the probe always executes at request time rather than being statically optimized
+- Unaffected by `middleware.ts`, whose matcher covers only page routes
+- Coolify config: path `/api/health`, port 3000, interval 30s, timeout 5s, retries 3, start period 40s
+
 ## 2026-06-15 — AI Assessment tab (Analytics)
 
 ### AI-powered financial assessment

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+// Pinned so the probe always executes at request time. A statically optimized
+// response would still return 200 from a server that had stopped working.
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/health
+ *
+ * Container liveness probe for the Coolify/Docker healthcheck. Deliberately
+ * touches neither the database nor auth: every app on this host shares one
+ * Postgres instance, so a deep check would mark them all unhealthy during a
+ * single database blip and restart the lot at once. This answers only "is the
+ * server serving HTTP?".
+ */
+export function GET() {
+  return NextResponse.json({ status: "ok" }, { status: 200 });
+}


### PR DESCRIPTION
## What

Adds `GET /api/health`, a shallow liveness probe returning `{ status: "ok" }` with a 200. Also documents it in the AGENTS.md API Routes Reference and the changelog, per the repo requirement to update docs when routes change.

## Why

Five Coolify containers on the shared host crash-looped for roughly 11 hours after the shared Postgres failed to come up. Traefik served 503s the whole time with no signal, because no app container defines a healthcheck. This gives Coolify something to probe.

The probe deliberately touches neither the database nor auth. All ten apps on that host share one Postgres instance, so a deep check would mark them all unhealthy during a single database blip and restart the lot at once, which is a worse version of the outage it is meant to surface.

## Notes

- `dynamic = "force-dynamic"` is pinned so the probe always runs at request time. A statically optimized response would still return 200 from a server that had stopped working.
- Unaffected by `middleware.ts`, whose matcher covers only page routes (`/dashboard`, `/transactions`, `/bills`, `/categories`, `/profile`, `/admin`). Verified before writing the route.
- Port 3000 confirmed from `nixpacks.toml` (`PORT=3000 node .next/standalone/server.js`) and by probing the running container, not assumed.

## Coolify configuration

Already staged on the application so the deploy from this merge bakes it in:

```
Path:          /api/health
Port:          3000
Interval:      30s
Timeout:       5s
Retries:       3
Start period:  40s
```

## Verification

- `pnpm lint`: No ESLint warnings or errors
- `pnpm type-check`: 0 errors
- Husky pre-commit (`eslint --max-warnings 0`) and pre-push (`type-check`) both passed
- Runtime: `HTTP 200` with `{"status":"ok"}`

Manual test plan: hit `/api/health` on the deployed container and confirm a 200; confirm `docker inspect` reports the container `healthy`.

## Cost

Roughly 0.3% of the host's 2 vCPU across all apps at a 30s interval. Measured warm latency in dev was noisy on this app (Next 15 dev-server overhead, ~120ms baseline on any routed request), so the real per-probe cost will be measured in-container after deploy rather than extrapolated from dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/api/health` endpoint that returns a simple successful status for container health checks.
  * The liveness check runs at request time without requiring authentication or database access.

* **Documentation**
  * Documented the endpoint and its container health-check configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->