### PR TITLE
fix(pwa): make the install prompt actually appear, plus 6 related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable development history for the Budget Tracker app.
 
+## 2026-08-20 - PWA Install Prompt Fixes
+
+### Install prompt reliability
+- **Root cause fix**: Chrome fires `beforeinstallprompt` once, shortly after load, and the only listener lived inside a `useEffect`. On the authenticated shell, hydration often finished after the event fired, and the event never replays, so `canInstall` stayed `false` for the whole session and the banner never appeared. The event is now captured by an inline script in the root layout at parse time and adopted by `useInstallPrompt` via a `bip-ready` event
+- The stashed prompt is cleared as soon as it is consumed or the app is installed, since `prompt()` throws if called twice
+- Banner now hides when the app is installed from the browser's own menu. `appinstalled` previously left a visible banner on screen
+- Installed-PWA detection adds `navigator.standalone`, so iOS before 16.4 no longer shows the "Add to Home Screen" guide inside the installed app
+
+### Layout and robustness
+- Install banner no longer paints over the bill reminder. Both were fixed to the same corner (install `4.5rem`/`z-40`, bill `5rem`/`z-20`); the install card now offsets by the bill banner height, which is what `MobileFab` already assumed. Clearance passes as a CSS variable so the `lg:` breakpoint keeps its own base offset
+- `localStorage` access is guarded. It throws in embedded webviews and when site data is blocked, and these calls run in effects inside `AppShell`, so an uncaught throw took down the whole authenticated shell for a cosmetic nudge
+
+### Accessibility and access
+- Banner is a labelled `region` instead of an `aria-live` status: a live region announced the text but gave screen reader users no route to the buttons inside it. Escape now dismisses it, cooldown included
+- New **Install App** row in Profile > Features (`src/components/pwa/install-app-card.tsx`), the way back in after the banner's 14-day dismissal. Handles installed / installable / iOS / unsupported states
+- `manifest.ts` pins `id: "/dashboard"` (the current implicit value) so future `start_url` changes cannot orphan existing installs
+
 ## 2026-07-28 — Container Liveness Endpoint
 
 ### Health Check

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,6 +53,20 @@ export default function RootLayout({
     <html lang="en" className={`${youngSerif.variable} ${outfit.variable} ${plusJakarta.variable}`}>
       <head>
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+        {/*
+          Chrome fires `beforeinstallprompt` once, shortly after load and often
+          before React hydrates. The event never replays, so capture it at parse
+          time and let `useInstallPrompt` adopt it via the `bip-ready` event.
+        */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "window.__bipEvent=null;" +
+              "window.addEventListener('beforeinstallprompt',function(e){" +
+              "e.preventDefault();window.__bipEvent=e;" +
+              "window.dispatchEvent(new Event('bip-ready'))});",
+          }}
+        />
       </head>
       <body className="font-sans antialiased">
         <SerwistProvider swUrl="/sw.js" reloadOnOnline={false} disable={process.env.NODE_ENV === "development"}>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -2,6 +2,9 @@ import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
+    // Matches the current implicit id (which defaults to start_url), so already
+    // installed apps keep their identity. Changing this orphans them.
+    id: "/dashboard",
     name: "Budget Tracker",
     short_name: "Budget",
     description: "Track your income and expenses with ease",

--- a/src/components/profile/features-form.tsx
+++ b/src/components/profile/features-form.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ScanLine, Mail, Rows3, Target, Tag } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useUser } from "@/components/user-provider";
+import { InstallAppCard } from "@/components/pwa/install-app-card";
 
 export function FeaturesForm() {
   const { user, setUser } = useUser();
@@ -292,6 +293,8 @@ export function FeaturesForm() {
             />
           </button>
         </div>
+
+        <InstallAppCard />
 
         <div className="p-4 rounded-xl border border-cream-300 bg-cream-50/50">
           <div className="flex items-center gap-3 mb-3">

--- a/src/components/pwa/install-app-card.tsx
+++ b/src/components/pwa/install-app-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Download, Check, Share } from "lucide-react";
 import { useInstallPrompt } from "@/hooks/use-install-prompt";
 import { cn } from "@/lib/utils";
@@ -22,6 +22,13 @@ function isIOS() {
 export function InstallAppCard() {
   const { canInstall, isInstalled, promptInstall } = useInstallPrompt();
   const [installing, setInstalling] = useState(false);
+  // Detected after mount, not during render: this page is server-rendered, where
+  // navigator is undefined, so calling isIOS() inline would mismatch hydration.
+  const [isIOSDevice, setIsIOSDevice] = useState(false);
+
+  useEffect(() => {
+    setIsIOSDevice(isIOS());
+  }, []);
 
   const handleInstall = async () => {
     setInstalling(true);
@@ -36,7 +43,7 @@ export function InstallAppCard() {
     ? "You're using the installed app"
     : canInstall
       ? "Add Budget Tracker to your home screen for quick access"
-      : isIOS()
+      : isIOSDevice
         ? 'Tap the share button, then "Add to Home Screen"'
         : "Use your browser menu to install this app";
 
@@ -44,7 +51,7 @@ export function InstallAppCard() {
     <div className="flex items-center justify-between gap-4 p-4 rounded-xl border border-cream-300 bg-cream-50/50">
       <div className="flex items-center gap-3">
         <div className="w-10 h-10 rounded-xl bg-amber-light flex items-center justify-center">
-          {isIOS() && !isInstalled && !canInstall ? (
+          {isIOSDevice && !isInstalled && !canInstall ? (
             <Share className="w-5 h-5 text-amber-dark" />
           ) : (
             <Download className="w-5 h-5 text-amber-dark" />
@@ -67,7 +74,7 @@ export function InstallAppCard() {
           disabled={installing}
           onClick={handleInstall}
           className={cn(
-            "px-4 py-2 rounded-xl text-sm font-medium transition-colors shrink-0",
+            "px-4 py-2.5 rounded-xl text-sm font-medium transition-colors shrink-0",
             "bg-amber text-white hover:bg-amber-dark disabled:opacity-50 disabled:cursor-not-allowed"
           )}
         >

--- a/src/components/pwa/install-app-card.tsx
+++ b/src/components/pwa/install-app-card.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { Download, Check, Share } from "lucide-react";
+import { useInstallPrompt } from "@/hooks/use-install-prompt";
+import { cn } from "@/lib/utils";
+
+// navigator.userAgent is deprecated but navigator.userAgentData is not yet
+// supported on iOS Safari, so UA sniffing remains the pragmatic choice here.
+function isIOS() {
+  if (typeof navigator === "undefined") return false;
+  if (/iPhone|iPod|iPad/.test(navigator.userAgent)) return true;
+  // iPadOS 13+ reports as Macintosh — detect via multi-touch support
+  return /Macintosh/.test(navigator.userAgent) && navigator.maxTouchPoints > 1;
+}
+
+/**
+ * Install entry point for Profile > Features. The install banner can be
+ * dismissed for 14 days, so this is the way back in. It works because the
+ * deferred prompt is captured before hydration and kept until consumed.
+ */
+export function InstallAppCard() {
+  const { canInstall, isInstalled, promptInstall } = useInstallPrompt();
+  const [installing, setInstalling] = useState(false);
+
+  const handleInstall = async () => {
+    setInstalling(true);
+    try {
+      await promptInstall();
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  const description = isInstalled
+    ? "You're using the installed app"
+    : canInstall
+      ? "Add Budget Tracker to your home screen for quick access"
+      : isIOS()
+        ? 'Tap the share button, then "Add to Home Screen"'
+        : "Use your browser menu to install this app";
+
+  return (
+    <div className="flex items-center justify-between gap-4 p-4 rounded-xl border border-cream-300 bg-cream-50/50">
+      <div className="flex items-center gap-3">
+        <div className="w-10 h-10 rounded-xl bg-amber-light flex items-center justify-center">
+          {isIOS() && !isInstalled && !canInstall ? (
+            <Share className="w-5 h-5 text-amber-dark" />
+          ) : (
+            <Download className="w-5 h-5 text-amber-dark" />
+          )}
+        </div>
+        <div>
+          <p className="text-sm font-medium text-warm-600">Install App</p>
+          <p className="text-xs text-warm-400">{description}</p>
+        </div>
+      </div>
+
+      {isInstalled ? (
+        <span className="flex items-center gap-1.5 text-xs font-medium text-warm-400 shrink-0">
+          <Check className="w-4 h-4" />
+          Installed
+        </span>
+      ) : canInstall ? (
+        <button
+          type="button"
+          disabled={installing}
+          onClick={handleInstall}
+          className={cn(
+            "px-4 py-2 rounded-xl text-sm font-medium transition-colors shrink-0",
+            "bg-amber text-white hover:bg-amber-dark disabled:opacity-50 disabled:cursor-not-allowed"
+          )}
+        >
+          {installing ? "Installing..." : "Install"}
+        </button>
+      ) : (
+        <span className="text-xs text-warm-400 shrink-0">Not available</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/pwa/install-app-card.tsx
+++ b/src/components/pwa/install-app-card.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 function isIOS() {
   if (typeof navigator === "undefined") return false;
   if (/iPhone|iPod|iPad/.test(navigator.userAgent)) return true;
-  // iPadOS 13+ reports as Macintosh — detect via multi-touch support
+  // iPadOS 13+ reports as Macintosh, so detect via multi-touch support
   return /Macintosh/.test(navigator.userAgent) && navigator.maxTouchPoints > 1;
 }
 

--- a/src/components/pwa/install-prompt-banner.tsx
+++ b/src/components/pwa/install-prompt-banner.tsx
@@ -91,6 +91,16 @@ export function InstallPromptBanner() {
     }
   }, [canInstall, isInstalled, setVisible]);
 
+  // Another entry point (the profile card) claimed the prompt and the user
+  // dismissed the native dialog, so nothing was installed but there is no
+  // longer anything to offer here. Only hides, so it cannot fight the effect
+  // above. No dismissal is recorded -- the user never dismissed this banner.
+  useEffect(() => {
+    if (visible && !showIOSGuide && !canInstall && !isInstalled) {
+      setVisible(false);
+    }
+  }, [visible, showIOSGuide, canInstall, isInstalled, setVisible]);
+
   useEffect(() => {
     if (!visible) return;
 

--- a/src/components/pwa/install-prompt-banner.tsx
+++ b/src/components/pwa/install-prompt-banner.tsx
@@ -36,7 +36,11 @@ export function InstallPromptBanner() {
 
   // Show banner when conditions are met
   useEffect(() => {
-    if (isInstalled) return;
+    // Also covers installing from the browser's own menu while the banner is up
+    if (isInstalled) {
+      setVisible(false);
+      return;
+    }
 
     const dismissedAt = localStorage.getItem(DISMISS_KEY);
     if (dismissedAt) {

--- a/src/components/pwa/install-prompt-banner.tsx
+++ b/src/components/pwa/install-prompt-banner.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import type { CSSProperties } from "react";
 import { Download, X, Share } from "lucide-react";
 import { useInstallPrompt } from "@/hooks/use-install-prompt";
 import { useInstallBanner } from "@/components/pwa/install-banner-context";
+import { useBillReminders } from "@/components/bills/bill-reminder-provider";
 import { cn } from "@/lib/utils";
 
 const DISMISS_KEY = "pwa-install-dismissed-at";
 const MIN_VISITS_KEY = "pwa-visit-count";
 const MIN_VISITS = 3;
 const DISMISS_DAYS = 14;
+const BILL_BANNER_GAP_PX = 12;
 
 // navigator.userAgent is deprecated but navigator.userAgentData is not yet
 // supported on iOS Safari, so UA sniffing remains the pragmatic choice here.
@@ -25,6 +28,7 @@ function isIOS() {
 export function InstallPromptBanner() {
   const { canInstall, isInstalled, promptInstall } = useInstallPrompt();
   const { bannerVisible: visible, setBannerVisible: setVisible, setBannerHeight } = useInstallBanner();
+  const { bannerHeight: billBannerHeight } = useBillReminders();
   const [showIOSGuide, setShowIOSGuide] = useState(false);
   const bannerRef = useRef<HTMLDivElement | null>(null);
 
@@ -103,8 +107,18 @@ export function InstallPromptBanner() {
 
   if (!visible) return null;
 
+  // Sit above the bill reminder rather than over it -- MobileFab already sums
+  // both clearances, so it assumes the two banners stack.
+  const billClearance = billBannerHeight > 0 ? billBannerHeight + BILL_BANNER_GAP_PX : 0;
+
   return (
-    <div ref={bannerRef} role="status" aria-live="polite" className="fixed bottom-[calc(4.5rem+env(safe-area-inset-bottom))] lg:bottom-6 left-4 right-4 lg:left-auto lg:right-6 lg:w-80 z-40 animate-fade-in-up">
+    <div
+      ref={bannerRef}
+      role="status"
+      aria-live="polite"
+      style={{ "--bill-clearance": `${billClearance}px` } as CSSProperties}
+      className="fixed bottom-[calc(4.5rem+var(--bill-clearance)+env(safe-area-inset-bottom))] lg:bottom-[calc(1.5rem+var(--bill-clearance))] left-4 right-4 lg:left-auto lg:right-6 lg:w-80 z-40 animate-fade-in-up"
+    >
       <div className="bg-white rounded-2xl shadow-soft-md border border-cream-300/50 p-4">
         <div className="flex items-start gap-3">
           <div className="w-10 h-10 rounded-xl bg-amber-light flex items-center justify-center shrink-0">

--- a/src/components/pwa/install-prompt-banner.tsx
+++ b/src/components/pwa/install-prompt-banner.tsx
@@ -14,6 +14,33 @@ const MIN_VISITS = 3;
 const DISMISS_DAYS = 14;
 const BILL_BANNER_GAP_PX = 12;
 
+// Storage access throws in embedded webviews and when site data is blocked, and
+// writes can throw in Safari private mode. This banner is cosmetic, so a storage
+// failure must degrade to "never shown" rather than take down the app shell.
+const safeGet = (key: string): string | null => {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const safeSet = (key: string, value: string) => {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // ignore
+  }
+};
+
+const safeRemove = (key: string) => {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // ignore
+  }
+};
+
 // navigator.userAgent is deprecated but navigator.userAgentData is not yet
 // supported on iOS Safari, so UA sniffing remains the pragmatic choice here.
 function isIOS() {
@@ -34,8 +61,8 @@ export function InstallPromptBanner() {
 
   // Track visits on mount only — not on canInstall/isInstalled changes
   useEffect(() => {
-    const visits = parseInt(localStorage.getItem(MIN_VISITS_KEY) || "0", 10) + 1;
-    localStorage.setItem(MIN_VISITS_KEY, String(visits));
+    const visits = parseInt(safeGet(MIN_VISITS_KEY) || "0", 10) + 1;
+    safeSet(MIN_VISITS_KEY, String(visits));
   }, []);
 
   // Show banner when conditions are met
@@ -46,14 +73,14 @@ export function InstallPromptBanner() {
       return;
     }
 
-    const dismissedAt = localStorage.getItem(DISMISS_KEY);
+    const dismissedAt = safeGet(DISMISS_KEY);
     if (dismissedAt) {
       const daysSince = (Date.now() - parseInt(dismissedAt, 10)) / (1000 * 60 * 60 * 24);
       if (daysSince < DISMISS_DAYS) return;
-      localStorage.removeItem(DISMISS_KEY);
+      safeRemove(DISMISS_KEY);
     }
 
-    const visits = parseInt(localStorage.getItem(MIN_VISITS_KEY) || "0", 10);
+    const visits = parseInt(safeGet(MIN_VISITS_KEY) || "0", 10);
     if (visits < MIN_VISITS) return;
 
     if (canInstall) {
@@ -96,7 +123,7 @@ export function InstallPromptBanner() {
 
   const handleDismiss = () => {
     setVisible(false);
-    localStorage.setItem(DISMISS_KEY, String(Date.now()));
+    safeSet(DISMISS_KEY, String(Date.now()));
   };
 
   const handleInstall = async () => {

--- a/src/components/pwa/install-prompt-banner.tsx
+++ b/src/components/pwa/install-prompt-banner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import type { CSSProperties } from "react";
 import { Download, X, Share } from "lucide-react";
 import { useInstallPrompt } from "@/hooks/use-install-prompt";
@@ -121,10 +121,22 @@ export function InstallPromptBanner() {
     };
   }, [visible, setBannerHeight]);
 
-  const handleDismiss = () => {
+  const handleDismiss = useCallback(() => {
     setVisible(false);
     safeSet(DISMISS_KEY, String(Date.now()));
-  };
+  }, [setVisible]);
+
+  // Escape dismisses like the close button, cooldown included
+  useEffect(() => {
+    if (!visible) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleDismiss();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [visible, handleDismiss]);
 
   const handleInstall = async () => {
     await promptInstall();
@@ -141,8 +153,8 @@ export function InstallPromptBanner() {
   return (
     <div
       ref={bannerRef}
-      role="status"
-      aria-live="polite"
+      role="region"
+      aria-label="Install Budget Tracker"
       style={{ "--bill-clearance": `${billClearance}px` } as CSSProperties}
       className="fixed bottom-[calc(4.5rem+var(--bill-clearance)+env(safe-area-inset-bottom))] lg:bottom-[calc(1.5rem+var(--bill-clearance))] left-4 right-4 lg:left-auto lg:right-6 lg:w-80 z-40 animate-fade-in-up"
     >

--- a/src/components/pwa/install-prompt-banner.tsx
+++ b/src/components/pwa/install-prompt-banner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import type { CSSProperties } from "react";
+import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { Download, X, Share } from "lucide-react";
 import { useInstallPrompt } from "@/hooks/use-install-prompt";
 import { useInstallBanner } from "@/components/pwa/install-banner-context";
@@ -126,17 +126,12 @@ export function InstallPromptBanner() {
     safeSet(DISMISS_KEY, String(Date.now()));
   }, [setVisible]);
 
-  // Escape dismisses like the close button, cooldown included
-  useEffect(() => {
-    if (!visible) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") handleDismiss();
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [visible, handleDismiss]);
+  // Scoped to the banner, not the document: Modal already closes on a document
+  // Escape listener, and a global handler here would silently start the 14-day
+  // cooldown every time the user escaped an unrelated dialog.
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") handleDismiss();
+  };
 
   const handleInstall = async () => {
     await promptInstall();
@@ -153,6 +148,7 @@ export function InstallPromptBanner() {
   return (
     <div
       ref={bannerRef}
+      onKeyDown={handleKeyDown}
       role="region"
       aria-label="Install Budget Tracker"
       style={{ "--bill-clearance": `${billClearance}px` } as CSSProperties}

--- a/src/hooks/use-install-prompt.ts
+++ b/src/hooks/use-install-prompt.ts
@@ -2,9 +2,33 @@
 
 import { useState, useEffect, useCallback } from "react";
 
-interface BeforeInstallPromptEvent extends Event {
+export interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<void>;
   userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+declare global {
+  interface Window {
+    /**
+     * Set by the inline capture script in the root layout. Chrome fires
+     * `beforeinstallprompt` once, shortly after load and often before React has
+     * hydrated — the event never replays, so it is stashed here at parse time.
+     */
+    __bipEvent?: BeforeInstallPromptEvent | null;
+  }
+}
+
+/** Chrome throws if `prompt()` is called twice, so a consumed event must not linger. */
+const clearStashedPrompt = () => {
+  window.__bipEvent = null;
+};
+
+function isRunningStandalone() {
+  if (window.matchMedia("(display-mode: standalone)").matches) return true;
+  // iOS before 16.4 reports display-mode incorrectly; navigator.standalone is
+  // the only reliable signal inside a home-screen PWA there.
+  const nav = navigator as Navigator & { standalone?: boolean };
+  return nav.standalone === true;
 }
 
 export function useInstallPrompt() {
@@ -14,10 +38,19 @@ export function useInstallPrompt() {
 
   useEffect(() => {
     // Check if already installed
-    if (window.matchMedia("(display-mode: standalone)").matches) {
+    if (isRunningStandalone()) {
       setIsInstalled(true);
       return;
     }
+
+    // Adopt an event the inline capture script caught before hydration
+    if (window.__bipEvent) {
+      setDeferredPrompt(window.__bipEvent);
+    }
+
+    const handleStashed = () => {
+      if (window.__bipEvent) setDeferredPrompt(window.__bipEvent);
+    };
 
     const handleBeforeInstall = (e: Event) => {
       e.preventDefault();
@@ -27,12 +60,15 @@ export function useInstallPrompt() {
     const handleAppInstalled = () => {
       setIsInstalled(true);
       setDeferredPrompt(null);
+      clearStashedPrompt();
     };
 
+    window.addEventListener("bip-ready", handleStashed);
     window.addEventListener("beforeinstallprompt", handleBeforeInstall);
     window.addEventListener("appinstalled", handleAppInstalled);
 
     return () => {
+      window.removeEventListener("bip-ready", handleStashed);
       window.removeEventListener("beforeinstallprompt", handleBeforeInstall);
       window.removeEventListener("appinstalled", handleAppInstalled);
     };
@@ -40,9 +76,12 @@ export function useInstallPrompt() {
 
   const promptInstall = useCallback(async () => {
     if (!deferredPrompt) return false;
+    // Drop the reference first — the event is spent the moment prompt() runs,
+    // so a second caller must not be able to reuse it.
+    setDeferredPrompt(null);
+    clearStashedPrompt();
     await deferredPrompt.prompt();
     const { outcome } = await deferredPrompt.userChoice;
-    setDeferredPrompt(null);
     return outcome === "accepted";
   }, [deferredPrompt]);
 

--- a/src/hooks/use-install-prompt.ts
+++ b/src/hooks/use-install-prompt.ts
@@ -12,7 +12,7 @@ declare global {
     /**
      * Set by the inline capture script in the root layout. Chrome fires
      * `beforeinstallprompt` once, shortly after load and often before React has
-     * hydrated — the event never replays, so it is stashed here at parse time.
+     * hydrated. The event never replays, so it is stashed here at parse time.
      */
     __bipEvent?: BeforeInstallPromptEvent | null;
   }
@@ -76,7 +76,7 @@ export function useInstallPrompt() {
 
   const promptInstall = useCallback(async () => {
     if (!deferredPrompt) return false;
-    // Drop the reference first — the event is spent the moment prompt() runs,
+    // Drop the reference first: the event is spent the moment prompt() runs,
     // so a second caller must not be able to reuse it.
     setDeferredPrompt(null);
     clearStashedPrompt();

--- a/src/hooks/use-install-prompt.ts
+++ b/src/hooks/use-install-prompt.ts
@@ -18,9 +18,17 @@ declare global {
   }
 }
 
-/** Chrome throws if `prompt()` is called twice, so a consumed event must not linger. */
+/**
+ * Chrome throws if `prompt()` is called twice, so a consumed event must not
+ * linger. Several components use this hook at once (the banner and the profile
+ * card are both mounted on /profile) and each holds its own copy of the event,
+ * so clearing the stash alone is not enough: every instance has to be told.
+ */
+const CONSUMED_EVENT = "bip-consumed";
+
 const clearStashedPrompt = () => {
   window.__bipEvent = null;
+  window.dispatchEvent(new Event(CONSUMED_EVENT));
 };
 
 function isRunningStandalone() {
@@ -63,11 +71,16 @@ export function useInstallPrompt() {
       clearStashedPrompt();
     };
 
+    // Another instance claimed the event; ours is now spent
+    const handleConsumed = () => setDeferredPrompt(null);
+
+    window.addEventListener(CONSUMED_EVENT, handleConsumed);
     window.addEventListener("bip-ready", handleStashed);
     window.addEventListener("beforeinstallprompt", handleBeforeInstall);
     window.addEventListener("appinstalled", handleAppInstalled);
 
     return () => {
+      window.removeEventListener(CONSUMED_EVENT, handleConsumed);
       window.removeEventListener("bip-ready", handleStashed);
       window.removeEventListener("beforeinstallprompt", handleBeforeInstall);
       window.removeEventListener("appinstalled", handleAppInstalled);
@@ -76,13 +89,17 @@ export function useInstallPrompt() {
 
   const promptInstall = useCallback(async () => {
     if (!deferredPrompt) return false;
-    // Drop the reference first: the event is spent the moment prompt() runs,
-    // so a second caller must not be able to reuse it.
-    setDeferredPrompt(null);
+    // Claim the event before prompting so no other instance can reuse it, and
+    // so every entry point stops offering an install that would now throw.
     clearStashedPrompt();
-    await deferredPrompt.prompt();
-    const { outcome } = await deferredPrompt.userChoice;
-    return outcome === "accepted";
+    try {
+      await deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+      return outcome === "accepted";
+    } catch {
+      // Already consumed, or the browser refused to show the dialog
+      return false;
+    }
   }, [deferredPrompt]);
 
   return {


### PR DESCRIPTION
## Summary

- The "Install Budget Tracker" banner effectively never appeared in production. Chrome fires `beforeinstallprompt` once, shortly after load, and the only listener lived inside a `useEffect`. On the authenticated shell, hydration often finished after the event fired, and the event never replays, so `canInstall` stayed `false` for the whole session.
- Investigating that surfaced five more defects around the same feature, including one where the install card painted over an overdue bill reminder, and one where unguarded `localStorage` could take down the entire authenticated shell.
- Also adds the two smallest safe improvements: an install entry point in Profile (the banner can be dismissed for 14 days with no way back in) and a pinned manifest `id`.

## Changes

### Install prompt reliability
- `src/app/layout.tsx` captures `beforeinstallprompt` in an inline `<head>` script at parse time; `src/hooks/use-install-prompt.ts` adopts it via a `bip-ready` event. Verified in the build output: the script is synchronous in `<head>` while every app chunk is `async`.
- The stash is cleared as soon as the prompt is consumed or the app is installed, since `prompt()` throws if called twice.
- The banner now hides when the app is installed from the browser's own menu. `appinstalled` previously left it on screen, still prompting the user to install an app they had just installed.
- Installed-PWA detection adds `navigator.standalone`, so iOS before 16.4 stops showing the "Add to Home Screen" guide inside the installed app.

### Layout and robustness
- The install banner no longer covers the bill reminder. Both were fixed to the same corner (install `4.5rem`/`z-40`, bill `5rem`/`z-20`). `MobileFab` already summed both clearances, meaning it was written assuming the banners stack, so this makes that assumption true and needs no FAB change. Clearance passes as a CSS variable rather than an inline `bottom` so the `lg:` breakpoint keeps its own base offset.
- `localStorage` access is guarded. It throws in embedded webviews and when site data is blocked, and these calls run in effects inside `AppShell`, so an uncaught throw took down the whole authenticated shell for a cosmetic nudge.

### Accessibility and access
- The banner is a labelled `region` instead of an `aria-live` status. A live region announced the text but gave screen reader users no route to the buttons inside it.
- Escape dismisses the banner, scoped to the banner element. A document-level handler would also fire when closing any `Modal` (which closes on its own document Escape listener), silently starting the 14-day cooldown from an unrelated dialog.
- New **Install App** row in Profile > Features (`src/components/pwa/install-app-card.tsx`), handling installed / installable / iOS / unsupported states. Separate component because `features-form.tsx` is already well past the component size guideline.
- `src/app/manifest.ts` pins `id: "/dashboard"`, deliberately matching the current implicit id (which defaults to `start_url`) so already-installed apps keep their identity.

## Test plan

Requires a deployed build. `beforeinstallprompt` needs HTTPS plus a live service worker, and Serwist is disabled in dev (`next.config.ts:14`), so none of the Chrome path is testable via `pnpm dev`.

Reset between runs: clear site data, uninstall from `chrome://apps`, and
```js
localStorage.removeItem("pwa-install-dismissed-at");
localStorage.removeItem("pwa-visit-count");
```

- [ ] Chrome desktop, fresh profile: banner appears on the 3rd load of an app page
- [ ] `window.__bipEvent` is non-null right after load, before hydration (proves the race is closed)
- [ ] "Install App" opens the Chrome dialog, banner hides, app installs
- [ ] Reopening the installed app shows no banner
- [ ] With the banner up, installing via Chrome's menu makes it disappear
- [ ] After dismissing, Profile > Features offers Install with no `prompt() may only be called once` error
- [ ] Overdue bill + install banner on a mobile viewport: cards stack, FAB clears both
- [ ] Blocking site data in DevTools does not crash the app shell
- [ ] iPhone Safari: share-sheet guide appears; no banner inside the installed app
- [ ] Escape inside the banner dismisses it; Escape closing an unrelated modal does not
- [ ] A device with the app already installed still sees it as the same app after deploy

Passing locally: `pnpm lint`, `pnpm type-check`, and a full production build.

## Notes

- No breaking changes, no migrations, no new environment variables or dependencies.
- No routes or env vars changed, so `AGENTS.md` needs no update. `CHANGELOG.md` has a dated entry.
- Out of scope by agreement: manifest `screenshots` (needs real PNG assets) and install guides for Firefox Android / desktop Safari, which currently get no hint at all.

https://claude.ai/code/session_01Q9HrrkPQDWaEuW22f75GM5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Install App” option under Profile > Features.
  * Improved app installation prompts across supported browsers and iOS, including clearer platform-specific guidance.
* **Bug Fixes**
  * Install prompts now appear more reliably and disappear after installation or dismissal.
  * Prevented the install banner from overlapping bill reminders.
  * Improved behavior in embedded browsers where storage access may be restricted.
* **Accessibility**
  * Added Escape-key dismissal and improved banner labeling for assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->