### PR TITLE
chore: run dev server on port 3111

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 DATABASE_URL="postgres://myuser:mypassword@localhost:5432/budgettracker-nextjs"
 NEXTAUTH_SECRET="change-this-to-a-random-secret-in-production"
-NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_URL="http://localhost:3111"
 
 # Resend (email verification + password reset)
 RESEND_API_KEY=""

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ cp .env.example .env
 ```env
 DATABASE_URL="postgres://myuser:mypassword@localhost:5432/budgettracker-nextjs"
 NEXTAUTH_SECRET="change-this-to-a-random-secret-in-production"
-NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_URL="http://localhost:3111"
 
 # Google Gemini (optional — enables receipt scanning)
 GEMINI_API_KEY=""
@@ -137,7 +137,7 @@ pnpm db:seed
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000), register an account, and start tracking.
+Open [http://localhost:3111](http://localhost:3111), register an account, and start tracking.
 
 ## Available Scripts
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "packageManager": "pnpm@10.32.1",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack --port 3111",
     "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Summary

- Port 3000 is occupied by another project on this machine, so the local dev server moves to 3111.
- `NEXTAUTH_URL` moves with it. NextAuth builds auth callbacks from it, and `src/lib/email.ts:27` and `src/app/api/verify-email/route.ts:6` build the verification and password-reset links from it, so leaving it at 3000 would have pointed every email link at the wrong app.

## Changes

- `package.json`: `next dev --turbopack --port 3111`. Only the `dev` script changed; `build` and `start` are untouched.
- `.env.example` and `README.md`: updated to 3111 so a fresh clone matches the dev script.

The local `.env` was updated too, but it is gitignored and not part of this PR.

## Production impact

None. `nixpacks.toml` defines the whole Coolify deploy path and never invokes the `dev` script:

- install: `pnpm install --frozen-lockfile`
- build: `pnpm build`
- start: `HOSTNAME=0.0.0.0 PORT=3000 node .next/standalone/server.js`

The start command bypasses npm scripts entirely and sets `PORT=3000` explicitly. `.env.example` is not referenced by `nixpacks.toml`, `package.json`, or `next.config.ts` -- it is documentation, and Coolify injects real env vars from its own dashboard.

Deliberately unchanged because they refer to the port *inside* the container:

- `nixpacks.toml` start command
- the Coolify healthcheck on port 3000
- the bill-reminders cron (`curl http://localhost:3000/api/cron/bill-reminders`) documented in `AGENTS.md`

## Test plan

- [x] `pnpm dev` starts on `http://localhost:3111` (`Ready in 1625ms`)
- [x] `GET /` returns 200 and `/api/health` returns `{"status":"ok"}`
- [x] Port 3000 remains held by the other project; both listen side by side
- [ ] Log out and back in locally, since the existing NextAuth cookie was issued for `localhost:3000`

https://claude.ai/code/session_01Q9HrrkPQDWaEuW22f75GM5